### PR TITLE
Fix toshi sites bug

### DIFF
--- a/runzi/execute/openquake/oq_hazard_task.py
+++ b/runzi/execute/openquake/oq_hazard_task.py
@@ -274,7 +274,7 @@ class BuilderTask:
                     file_api.download_file(
                         file_id, target_dir=temp_dir, target_name="sites.csv"
                     )
-                    locations_file = temp_dir / "sites.csv"
+                    locations_file = Path(temp_dir) / "sites.csv"
                 else:
                     locations_file = Path(
                         task_arguments["site_params"]["locations_file"]

--- a/runzi/execute/openquake/oq_hazard_task.py
+++ b/runzi/execute/openquake/oq_hazard_task.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 import zipfile
 from pathlib import Path
+from typing import Dict, Any
 
 import requests
 from dateutil.tz import tzutc
@@ -199,6 +200,38 @@ class BuilderTask:
             ta_clean["gmcm_logic_tree"].replace('"', "``").replace("\n", "-")
         )
         return ta_clean
+    
+
+    # TODO: we need to consider the best way to pass args to toshiAPI and make the args such as logic
+    # trees and hazard config readable and (possibly) searchable.
+    @staticmethod
+    def _clean_task_args(task_arguments: Dict[str, Any]) -> Dict[str, str]:
+        """This is a somewhat clunky way to clean the arguments so they can be passed to the toshAPI"""
+
+        def flatten_dict(data, parent_key='', separator="-"):
+            flat_dict = {}
+            for k, v in data.items():
+                key = parent_key + separator + k if parent_key else k
+                if isinstance(v, dict):
+                    flat_dict.update(flatten_dict(v, key))
+                else:
+                    flat_dict[key] = v
+            return flat_dict
+
+        def clean_string(input_str):
+            return input_str.replace('"', "``").replace("\n", "-")
+        
+        ta_clean = copy.deepcopy(task_arguments)
+        slt = ta_clean["model"]["srm_logic_tree"]
+        glt = ta_clean["model"]["gmcm_logic_tree"]
+        config = ta_clean["model"]["hazard_config"]
+        ta_clean["model"]["srm_logic_tree"] = clean_string(str(slt))
+        ta_clean["model"]["gmcm_logic_tree"] = clean_string(str(glt))
+        ta_clean["model"]["hazard_config"] = clean_string(str(config))
+        return flatten_dict(ta_clean)
+
+
+
 
     def run(self, task_arguments, job_arguments):
         t0 = dt.datetime.now(dt.timezone.utc)
@@ -222,11 +255,11 @@ class BuilderTask:
         automation_task_id = None
         if self.use_api:
             # old config id until we've removed need for config_id when creating task
-            config_id = "T3BlbnF1YWtlSGF6YXJkQ29uZmlnOjEyOTI0NA=="
-            # ta_clean = self._sterilize_task_arguments_gmcmlt(ta)
-            # automation_task_id = self._setup_automation_task(ta_clean, ja, config_id, environment, task_type)
+            # config_id = "T3BlbnF1YWtlSGF6YXJkQ29uZmlnOjEyOTI0NA=="  # PROD
+            config_id = "T3BlbnF1YWtlSGF6YXJkQ29uZmlnOjEwMTU3MA=="  # TEST
+            ta_clean = self._clean_task_args(task_arguments)
             automation_task_id = self._setup_automation_task(
-                task_arguments, job_arguments, config_id, environment, task_type
+                ta_clean, job_arguments, config_id, environment, task_type
             )
 
         #################################
@@ -317,7 +350,7 @@ class BuilderTask:
         if self.use_api:
             solution_id = self._store_api_result(
                 automation_task_id,
-                task_arguments,
+                ta_clean,
                 oq_result,
                 config_id,
                 modconf_id=config_id,  # TODO use modified config id


### PR DESCRIPTION
- fixes problem with the locations file not being uploaded correctly (used when running in cloud)
- closes #185 by formatting task arguments properly

The new format for the task arguments passed to toshiAPI flattens the dict structure of the task args and uses the str representation of the `SourceLogicTree`, `GMCMLogicTree`, and `OpenquakeConfig`

Note that the `HazardConfig` object does not have a custom str representation and therefore no useful information provided. See https://github.com/GNS-Science/nzshm-model/issues/120 
```
{
  "data": {
    "node1": {
      "id": "R2VuZXJhbFRhc2s6MTAxNTg3",
      "children": {
        "total_count": 1,
        "edges": [
          {
            "node": {
              "child": {
                "arguments": [
                  {
                    "k": "general-title",
                    "v": "TEST Input"
                  },
                  {
                    "k": "general-description",
                    "v": "hazard test"
                  },
                  {
                    "k": "model-nshm_model_version",
                    "v": "NSHM_v1.0.4"
                  },
                  {
                    "k": "model-srm_logic_tree",
                    "v": "LogicTree type: <class 'nzshm_model.logic_tree.source_logic_tree.logic_tree.SourceLogicTree'>-title: Test SRM (IDs are found in TEST API), version:SLT_v9p0p0-==========BRANCH SETS==========--short_name: PUY, long_name: Puysegur-======BRANCHES======-SourceBranch(branch_id='0', weight=1.0, values=[dm0.7, bN[0.902, 4.6], C4.0, s0.28], sources=[InversionSource(nrml_id='SW52ZXJzaW9uU29sdXRpb25Ocm1sOjEwMDM0NQ==', rupture_rate_scaling=None, inversion_id='', rupture_set_id='', inversion_solution_type='', type='inversion')], rupture_rate_scaling=1.0, tectonic_region_types=('Subduction Interface',))"
                  },
                  {
                    "k": "model-gmcm_logic_tree",
                    "v": "LogicTree type: <class 'nzshm_model.logic_tree.gmcm_logic_tree.logic_tree.GMCMLogicTree'>-title: lt1, version:-==========BRANCH SETS==========--short_name: CRU, long_name: Crustal-======BRANCHES======-GMCMBranch(branch_id='', weight=0.117, gsim_name='Stafford2022', gsim_args={'mu_branch': 'Upper'}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.156, gsim_name='Stafford2022', gsim_args={'mu_branch': 'Central'}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.117, gsim_name='Stafford2022', gsim_args={'mu_branch': 'Lower'}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.084, gsim_name='Atkinson2022Crust', gsim_args={'epistemic': 'Upper', 'modified_sigma': 'true'}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.112, gsim_name='Atkinson2022Crust', gsim_args={'epistemic': 'Central', 'modified_sigma': 'true'}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.084, gsim_name='Atkinson2022Crust', gsim_args={'epistemic': 'Lower', 'modified_sigma': 'true'}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='AbrahamsonEtAl2014', gsim_args={'sigma_mu_epsilon': 1.28155}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0264, gsim_name='AbrahamsonEtAl2014', gsim_args={'sigma_mu_epsilon': 0.0}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='AbrahamsonEtAl2014', gsim_args={'sigma_mu_epsilon': -1.28155}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='BooreEtAl2014', gsim_args={'sigma_mu_epsilon': 1.28155}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0264, gsim_name='BooreEtAl2014', gsim_args={'sigma_mu_epsilon': 0.0}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='BooreEtAl2014', gsim_args={'sigma_mu_epsilon': -1.28155}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='CampbellBozorgnia2014', gsim_args={'sigma_mu_epsilon': 1.28155}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0264, gsim_name='CampbellBozorgnia2014', gsim_args={'sigma_mu_epsilon': 0.0}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='CampbellBozorgnia2014', gsim_args={'sigma_mu_epsilon': -1.28155}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='ChiouYoungs2014', gsim_args={'sigma_mu_epsilon': 1.28155}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0264, gsim_name='ChiouYoungs2014', gsim_args={'sigma_mu_epsilon': 0.0}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='ChiouYoungs2014', gsim_args={'sigma_mu_epsilon': -1.28155}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='Bradley2013', gsim_args={'sigma_mu_epsilon': 1.28155}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0264, gsim_name='Bradley2013', gsim_args={'sigma_mu_epsilon': 0.0}, tectonic_region_type='Active Shallow Crust')-GMCMBranch(branch_id='', weight=0.0198, gsim_name='Bradley2013', gsim_args={'sigma_mu_epsilon': -1.28155}, tectonic_region_type='Active Shallow Crust')--short_name: INTER, long_name: Subduction Interface-======BRANCHES======-GMCMBranch(branch_id='', weight=0.081, gsim_name='Atkinson2022SInter', gsim_args={'epistemic': 'Upper', 'modified_sigma': 'true'}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.108, gsim_name='Atkinson2022SInter', gsim_args={'epistemic': 'Central', 'modified_sigma': 'true'}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.081, gsim_name='Atkinson2022SInter', gsim_args={'epistemic': 'Lower', 'modified_sigma': 'true'}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.075, gsim_name='NZNSHM2022_AbrahamsonGulerce2020SInter', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': 1.28155}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.1, gsim_name='NZNSHM2022_AbrahamsonGulerce2020SInter', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': 0.0}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.075, gsim_name='NZNSHM2022_AbrahamsonGulerce2020SInter', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': -1.28155}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.072, gsim_name='NZNSHM2022_ParkerEtAl2020SInter', gsim_args={'sigma_mu_epsilon': 1.28155, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.096, gsim_name='NZNSHM2022_ParkerEtAl2020SInter', gsim_args={'sigma_mu_epsilon': 0.0, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.072, gsim_name='NZNSHM2022_ParkerEtAl2020SInter', gsim_args={'sigma_mu_epsilon': -1.28155, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.072, gsim_name='NZNSHM2022_KuehnEtAl2020SInter', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': 1.28155, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.096, gsim_name='NZNSHM2022_KuehnEtAl2020SInter', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': 0.0, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Interface')-GMCMBranch(branch_id='', weight=0.072, gsim_name='NZNSHM2022_KuehnEtAl2020SInter', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': -1.28155, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Interface')--short_name: SLAB, long_name: Subduction Intraslab-======BRANCHES======-GMCMBranch(branch_id='', weight=0.084, gsim_name='Atkinson2022SSlab', gsim_args={'epistemic': 'Upper', 'modified_sigma': 'true'}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.112, gsim_name='Atkinson2022SSlab', gsim_args={'epistemic': 'Central', 'modified_sigma': 'true'}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.084, gsim_name='Atkinson2022SSlab', gsim_args={'epistemic': 'Lower', 'modified_sigma': 'true'}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.075, gsim_name='NZNSHM2022_AbrahamsonGulerce2020SSlab', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': 1.28155}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.1, gsim_name='NZNSHM2022_AbrahamsonGulerce2020SSlab', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': 0.0}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.075, gsim_name='NZNSHM2022_AbrahamsonGulerce2020SSlab', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': -1.28155}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.069, gsim_name='NZNSHM2022_ParkerEtAl2020SSlab', gsim_args={'sigma_mu_epsilon': 1.28155, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.092, gsim_name='NZNSHM2022_ParkerEtAl2020SSlab', gsim_args={'sigma_mu_epsilon': 0.0, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.069, gsim_name='NZNSHM2022_ParkerEtAl2020SSlab', gsim_args={'sigma_mu_epsilon': -1.28155, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.072, gsim_name='NZNSHM2022_KuehnEtAl2020SSlab', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': 1.28155, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.096, gsim_name='NZNSHM2022_KuehnEtAl2020SSlab', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': 0.0, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Intraslab')-GMCMBranch(branch_id='', weight=0.072, gsim_name='NZNSHM2022_KuehnEtAl2020SSlab', gsim_args={'region': 'GLO', 'sigma_mu_epsilon': -1.28155, 'modified_sigma': 'true'}, tectonic_region_type='Subduction Intraslab')"
                  },
                  {
                    "k": "model-hazard_config",
                    "v": "<nzshm_model.psha_adapter.openquake.hazard_config.OpenquakeConfig object at 0x7f0d90229310>"
                  },
                  {
                    "k": "calculation-num_workers",
                    "v": "1"
                  },
                  {
                    "k": "hazard_curve-imts",
                    "v": "['PGA', 'SA(0.5)', 'SA(1.5)', 'SA(3.0)']"
                  },
                  {
                    "k": "hazard_curve-imtls",
                    "v": "[0.0001, 0.0002, 0.0004, 0.0006, 0.0008, 0.001, 0.002, 0.004, 0.006, 0.008, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]"
                  },
                  {
                    "k": "site_params-vs30",
                    "v": "400"
                  },
                  {
                    "k": "site_params-locations_file",
                    "v": "/home/chrisdc/NSHM/DEV/APP/nzshm-runzi/demo/sites.csv"
                  },
                  {
                    "k": "path",
                    "v": "/home/chrisdc/NSHM/DEV/APP/nzshm-runzi/demo/hazard_test.toml"
                  },
                  {
                    "k": "title",
                    "v": "TEST Input"
                  },
                  {
                    "k": "description",
                    "v": "hazard test"
                  },
                  {
                    "k": "task_type",
                    "v": "HAZARD"
                  },
                  {
                    "k": "model_type",
                    "v": "COMPOSITE"
                  }
                ]
              }
            }
          }
        ]
      }
    }
  }
}
```