### PR TITLE
add --docker flag and dev mode for running runzi in a local container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,58 +2,69 @@
 
 ## [unreleased]
 
-## Changed
+### Added
+ - --docker top-level flag to route any runzi command through a local Docker container, plus --dev build mode and dev_locally.md docs
+ - NZSHM22_OQ_VENV and NZSHM22_OQ_DATADIR environment variables for locating the OpenQuake venv and HDF5 datastore directory
+
+### Changed
  - Upgrade dependencies (gitpython 3.1.47 → 3.1.49, fixes CVE-2026-44244)
+ - Docker image now splits OpenQuake and runzi into separate venvs (/opt/oq-venv, /opt/runzi-venv)
+ - UCERF converter (oq_opensha_convert_task) now runs in oq-venv via subprocess, decoupling runzi from OpenQuake imports
+ - Renamed CLI command utils container → utils docker-build
+ - NZSHM22_TOSHI_API_ENABLED is no longer baked into the Docker image; set explicitly in AWS Batch job config and forwarded from host on local --docker runs
+ - oq-convert output zip is now written to WORK_PATH instead of being buried in a downloads/ subdirectory
+ - Container runs as host UID
+
 
 ## [0.10.1] 2026-03-30
 
-## Changed
+### Changed
  - Updated nzhsm-hazlab and nzshm-common dependencies to take advantage of fix to deserialization of CodedLocation.
  - Improved documentation to include missing env vars and correct command for running docker locally
  - Updated toshi-hazard-store to fix windows build problem due to lancedb
 
-## Added
+### Added
  - Save task arguments for disaggregation to toshiAPI.
 
 ## [0.10.0] 2026-03-12
 
-## Changed
+### Changed
  - `NZSHM22_SCRIPT_CLUSTER_MODE` environment variable replaced by `--cluster-mode` CLI option
  - Updated documentation to reflect `--cluster-mode` CLI argument
 
-## Added
+### Added
  - Tests for `--cluster-mode` CLI option (`tests/test_cli_cluster_mode.py`)
 
-## Removed
+### Removed
  - `NZSHM22_SCRIPT_CLUSTER_MODE` environment variable support
 
 ## [0.9.2] 2026-03-11
 
-## Added
+### Added
  - Shared validator module `runzi/tasks/validators.py` with `all_or_none`, `exactly_one`, `at_most_one`, and `resolve_path` helpers
  - Tests for all shared validators (`tests/test_validators.py`)
  - `ModuleWithDefaultSysArgs` protocol in `runzi/protocols.py` for task modules that expose `default_system_args`
 
-## Changed
+### Changed
  - Refactored inline validation logic in inversion, coulomb, and hazard task modules to use shared validators
  - Refactored task factories and job runner to use `ModuleWithDefaultSysArgs` protocol instead of untyped module references
 
 ## [0.9.1] 2026-03-10
 
-## Changed
+### Changed
  - Improved docker build with UCERF converter option
  - Documentation for building and running docker image
  - Reduced size of docker image
 
-## Added
+### Added
  - Script for building and deploying docker image
  
-## Removed
+### Removed
  - OpenQuake example input files
 
 ## [0.9.0] 2026-03-03
 
-## Changed
+### Changed
  - Complete refactor of job configuration and execution
    - Pydantic models for verification of input data
    - Simpler pattern for extending to new task types
@@ -61,29 +72,29 @@
    - CLI restructured into subcommands
  - Modernization of python dev standards (pyproject.toml, type hints, etc.)
 
-## Added
+### Added
  - Sideload paleoseismic recurrence interval
  - Sideload custom fault models
  - Sideload named faults
 
-## Removed
+### Removed
  - python3.9 support
 
 ## [0.1.0] 2025-*
 
-## Added
+### Added
 - Initial documentation
 - Development toolchain and workflows
 - Expand user paths for files specified in hazard config file
 - Hazard Task: docker image hash
 - Classes for specifying input arguments to scripts.
 
-## Changed
+### Changed
 - Hazard and disaggregation job configuration and parsing of sites handled by `nzhsm-model`
 - Hazard realizations written to arrow/parquet dataset with `toshi-hazard-store`
 - General Task: logic trees, location file, hazard config are uploaded as files
 - Hazard Task: logic trees, and hazard config are stored as json
 
-## Removed
+### Removed
  - Deleted unused automation scripts
  - Moved deprecated automation scripts to arkive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,8 @@ All runtime configuration is via environment variables (loaded from `.env` by py
 | `NZSHM22_FATJAR` | Path to OpenSHA fat JAR |
 | `NZSHM22_RUNZI_ECR_DIGEST` | AWS ECR image digest for ECS tasks |
 | `NZSHM22_THS_RLZ_DB` | toshi-hazard-store database config |
+| `NZSHM22_OQ_VENV` | Path to the OpenQuake virtual environment root (e.g. `/opt/oq-venv`); required for OQ tasks |
+| `NZSHM22_OQ_DATADIR` | Directory where `oq engine` writes HDF5 calc datastores (e.g. `/oqdata`); required for OQ tasks |
 
 ### Adding a New Task
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,6 +89,9 @@ ENV NZSHM22_OQ_DATADIR=/oqdata
 ENV PATH=/opt/runzi-venv/bin:$PATH
 RUN mkdir -p /oqdata && chmod 777 /oqdata
 
+ENV NUMBA_CACHE_DIR=/tmp/numba_cache
+RUN mkdir -p /tmp/numba_cache && chmod 777 /tmp/numba_cache
+
 ENTRYPOINT ["/bin/bash", "-c"]
 
 FROM runtime AS dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,6 +92,9 @@ RUN mkdir -p /oqdata && chmod 777 /oqdata
 ENV NUMBA_CACHE_DIR=/tmp/numba_cache
 RUN mkdir -p /tmp/numba_cache && chmod 777 /tmp/numba_cache
 
+ENV MPLCONFIGDIR=/tmp/matplotlib
+RUN mkdir -p /tmp/matplotlib && chmod 777 /tmp/matplotlib
+
 ENTRYPOINT ["/bin/bash", "-c"]
 
 FROM runtime AS dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,24 +31,26 @@ WORKDIR /opt/nzshm-opensha/build/libs
 RUN curl -sSL -o nzshm-opensha-all-${FATJAR_TAG}.jar \
     https://nzshm-opensha-public-jars.s3.ap-southeast-2.amazonaws.com/nzshm-opensha-all-${FATJAR_TAG}.jar
 
-# Install OpenQuake
+# oq-venv: OpenQuake (pinned requirements) — cached aggressively, rarely changes
+RUN python -m venv /opt/oq-venv
 RUN export PY_NO_DOT=$(echo $PYTHON_VERSION | tr -d '.') && \
-  pip install -r https://raw.githubusercontent.com/gem/oq-engine/refs/tags/v${OQ_VERSION}/requirements-py${PY_NO_DOT}-linux64.txt openquake.engine==${OQ_VERSION}
+    /opt/oq-venv/bin/pip install \
+        -r https://raw.githubusercontent.com/gem/oq-engine/refs/tags/v${OQ_VERSION}/requirements-py${PY_NO_DOT}-linux64.txt \
+        openquake.engine==${OQ_VERSION}
 
-# Optionally install UCERF converter
-WORKDIR /app
-COPY ucerf* /app/ucerf
+# Optional UCERF converter into oq-venv (INSTALL_CONVERTER=Y to enable)
 RUN if [ "$INSTALL_CONVERTER" = "Y" ] ; then \
-    cd /app/ucerf && pip install . ; \
+    cd /app/ucerf && /opt/oq-venv/bin/pip install . ; \
     fi
 
+# runzi-venv: runzi only — changes frequently, so comes after oq-venv
 WORKDIR /app
-# Install runzi
 RUN git clone https://github.com/GNS-Science/nzshm-runzi.git
 WORKDIR /app/nzshm-runzi
 RUN git fetch
 RUN git checkout ${RUNZI_GITREF}
-RUN pip install .
+RUN python -m venv /opt/runzi-venv
+RUN /opt/runzi-venv/bin/pip install .
 
 # RUN rm -r /app
 FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
@@ -81,11 +83,17 @@ ENV NZSHM22_BUILD_PLOTS=TRUE
 ENV PYTHON_PREP_MODULE=SET_AT_RUNTIME
 ENV PYTHON_TASK_MODULE=SET_AT_RUNTIME
 
+# OpenQuake venv isolation
+ENV NZSHM22_OQ_VENV=/opt/oq-venv
+ENV NZSHM22_OQ_DATADIR=/oqdata
+ENV PATH=/opt/runzi-venv/bin:$PATH
+RUN mkdir -p /oqdata && chmod 777 /oqdata
+
 ENTRYPOINT ["/bin/bash", "-c"]
 
 FROM runtime AS dev
 COPY --from=build /app/nzshm-runzi /app/nzshm-runzi
 WORKDIR /app/nzshm-runzi
-RUN pip install -e .
+RUN /opt/runzi-venv/bin/pip install -e .
 WORKDIR /WORKING
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN git checkout ${RUNZI_GITREF}
 RUN pip install .
 
 # RUN rm -r /app
-FROM python:${PYTHON_VERSION}-slim-bookworm
+FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
 ARG FATJAR_TAG
 COPY --from=build /usr /usr
 COPY --from=build /opt /opt
@@ -62,11 +62,14 @@ RUN chmod +x /usr/local/bin/python_container_task.sh
 
 # create the toshi-hazard-store dataset directory to store hazard realiztions locally
 WORKDIR /THS
-ENV NZSHM22_THS_RLZ_DB=/THS
+RUN mkdir HAZARD
+RUN mkdir DISAGG
+ENV NZSHM22_THS_RLZ_DB=/THS/HAZARD
+ENV NZSHM22_THS_DISAGG_RLZ_DB=/THS/DISAGG
 
 # Create working directory and set env vars
 WORKDIR /WORKING
-RUN mkdir -p /WORKING
+RUN mkdir -p /WORKING && chmod 0777 /WORKING /THS/HAZARD /THS/DISAGG
 ENV NZSHM22_TOSHI_API_ENABLED=1
 ENV NZSHM22_SCRIPT_WORK_PATH=/WORKING
 ENV NZSHM22_OPENSHA_JRE=/opt/java/bin
@@ -79,3 +82,10 @@ ENV PYTHON_PREP_MODULE=SET_AT_RUNTIME
 ENV PYTHON_TASK_MODULE=SET_AT_RUNTIME
 
 ENTRYPOINT ["/bin/bash", "-c"]
+
+FROM runtime AS dev
+COPY --from=build /app/nzshm-runzi /app/nzshm-runzi
+WORKDIR /app/nzshm-runzi
+RUN pip install -e .
+WORKDIR /WORKING
+ENV PYTHONDONTWRITEBYTECODE=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,6 @@ ENV NZSHM22_THS_DISAGG_RLZ_DB=/THS/DISAGG
 # Create working directory and set env vars
 WORKDIR /WORKING
 RUN mkdir -p /WORKING && chmod 0777 /WORKING /THS/HAZARD /THS/DISAGG
-ENV NZSHM22_TOSHI_API_ENABLED=1
 ENV NZSHM22_SCRIPT_WORK_PATH=/WORKING
 ENV NZSHM22_OPENSHA_JRE=/opt/java/bin
 ENV NZSHM22_FATJAR=/opt/nzshm-opensha/build/libs/nzshm-opensha-all-${FATJAR_TAG}.jar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,13 +86,9 @@ ENV PYTHON_TASK_MODULE=SET_AT_RUNTIME
 ENV NZSHM22_OQ_VENV=/opt/oq-venv
 ENV NZSHM22_OQ_DATADIR=/oqdata
 ENV PATH=/opt/runzi-venv/bin:$PATH
-RUN mkdir -p /oqdata && chmod 777 /oqdata
-
 ENV NUMBA_CACHE_DIR=/tmp/numba_cache
-RUN mkdir -p /tmp/numba_cache && chmod 777 /tmp/numba_cache
-
 ENV MPLCONFIGDIR=/tmp/matplotlib
-RUN mkdir -p /tmp/matplotlib && chmod 777 /tmp/matplotlib
+RUN mkdir -p /oqdata && chmod 777 /oqdata && mkdir -p /tmp/numba_cache && chmod 777 /tmp/numba_cache && mkdir -p /tmp/matplotlib && chmod 777 /tmp/matplotlib
 
 ENTRYPOINT ["/bin/bash", "-c"]
 

--- a/docker/python_container_task.sh
+++ b/docker/python_container_task.sh
@@ -1,4 +1,4 @@
 #This is the AWS CONTAINER SCRIPT for Python applications
 
-python3 -m ${PYTHON_TASK_MODULE} ${TASK_CONFIG_JSON_QUOTED}
+/opt/runzi-venv/bin/python -m ${PYTHON_TASK_MODULE} ${TASK_CONFIG_JSON_QUOTED}
 #END_OF_SCRIPT

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -353,18 +353,18 @@ $ runzi utils [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `container`: Build runzi-opensha Docker image, push to...
+* `docker-build`: Build runzi-opensha Docker image, push to...
 * `save-file`: Zip a file and save as a ToshiAPI File...
 * `index-inv`: Add inversions to the index (static web...
 
-### `utils container`
+### `utils docker-build`
 
 Build runzi-opensha Docker image, push to ECR, update Batch job definition.
 
 **Usage**:
 
 ```console
-$ runzi utils container [OPTIONS]
+$ runzi utils docker-build [OPTIONS]
 ```
 
 **Options**:

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -369,7 +369,7 @@ $ runzi utils container [OPTIONS]
 
 **Options**:
 
-* `--fatjar-tag TEXT`: OpenSHA fatjar tag  [default: bf70d35]
+* `--fatjar-tag TEXT`: OpenSHA fatjar tag
 * `--runzi-gitref TEXT`: Git branch, tag, or commit to build  [default: main]
 * `--python-version TEXT`: Python version  [default: 3.11]
 * `--oq-version TEXT`: OpenQuake version  [default: 3.23.4]

--- a/docs/usage/docker/build_and_deploy_container.md
+++ b/docs/usage/docker/build_and_deploy_container.md
@@ -17,7 +17,7 @@ This script is used to:
 The script is run via the runzi CLI:
 
 ```console
-$ runzi utils container [OPTIONS]
+$ runzi utils docker-build [OPTIONS]
 ```
 
 The script will print the image digest when completed. This is used to set the `NZSHM22_RUNZI_ECR_DIGEST` env var used by `toshi-hazard-store` to uniquely identify the code used to produce hazard realization curves.
@@ -90,7 +90,7 @@ JOB_DEFINITION=runzi_32GB_8VCPU_JD
 Deploy a new image with all defaults:
 
 ```bash
-runzi utils container --fatjar-tag bf70d35 --runzi-gitref main
+runzi utils docker-build --fatjar-tag bf70d35 --runzi-gitref main
 ```
 
 Or with environment variables:
@@ -98,7 +98,7 @@ Or with environment variables:
 ```bash
 export FATJAR_TAG=bf70d35
 export RUNZI_GITREF=main
-runzi utils container
+runzi utils docker-build
 ```
 
 ### Test Build Only
@@ -106,7 +106,7 @@ runzi utils container
 Build the image without pushing (useful for testing):
 
 ```bash
-runzi utils container --fatjar-tag bf70d35 --runzi-gitref main --skip-push
+runzi utils docker-build --fatjar-tag bf70d35 --runzi-gitref main --skip-push
 ```
 
 ### Specific Versions
@@ -114,7 +114,7 @@ runzi utils container --fatjar-tag bf70d35 --runzi-gitref main --skip-push
 Deploy with specific OpenQuake and Python versions:
 
 ```bash
-runzi utils container \
+runzi utils docker-build \
     --fatjar-tag bf70d35 \
     --runzi-gitref main \
     --oq-version 3.24.0 \
@@ -126,7 +126,7 @@ runzi utils container \
 Include the UCERF converter in the image:
 
 ```bash
-runzi utils container \
+runzi utils docker-build \
     --fatjar-tag bf70d35 \
     --runzi-gitref main \
     --install-converter
@@ -135,7 +135,7 @@ runzi utils container \
 ### Via runzi CLI
 
 ```bash
-runzi utils container \
+runzi utils docker-build \
     --fatjar-tag bf70d35 \
     --runzi-gitref main
 ```

--- a/docs/usage/docker/build_and_deploy_container.md
+++ b/docs/usage/docker/build_and_deploy_container.md
@@ -17,7 +17,7 @@ This script is used to:
 The script is run via the runzi CLI:
 
 ```console
-$ runzi utils deploy-docker [OPTIONS]
+$ runzi utils container [OPTIONS]
 ```
 
 The script will print the image digest when completed. This is used to set the `NZSHM22_RUNZI_ECR_DIGEST` env var used by `toshi-hazard-store` to uniquely identify the code used to produce hazard realization curves.
@@ -72,11 +72,11 @@ A `.env` in the project root can also be used to configure the script. Environme
 ```bash
 # Required
 FATJAR_TAG=bf70d35
-RUNZI_GITREF=main
+OQ_VERSION=3.23.4
 
 # Optional
 PYTHON_VERSION=3.11
-OQ_VERSION=3.23.4
+RUNZI_GITREF=main
 AWS_REGION=us-east-1
 AWS_ACCOUNT_ID=461564345538
 ECR_REPO=nzshm22/runzi
@@ -90,7 +90,7 @@ JOB_DEFINITION=runzi_32GB_8VCPU_JD
 Deploy a new image with all defaults:
 
 ```bash
-runzi utils deploy-docker --fatjar-tag bf70d35 --runzi-gitref main
+runzi utils container --fatjar-tag bf70d35 --runzi-gitref main
 ```
 
 Or with environment variables:
@@ -98,7 +98,7 @@ Or with environment variables:
 ```bash
 export FATJAR_TAG=bf70d35
 export RUNZI_GITREF=main
-runzi utils deploy-docker
+runzi utils container
 ```
 
 ### Test Build Only
@@ -106,7 +106,7 @@ runzi utils deploy-docker
 Build the image without pushing (useful for testing):
 
 ```bash
-runzi utils deploy-docker --fatjar-tag bf70d35 --runzi-gitref main --skip-push
+runzi utils container --fatjar-tag bf70d35 --runzi-gitref main --skip-push
 ```
 
 ### Specific Versions
@@ -114,7 +114,7 @@ runzi utils deploy-docker --fatjar-tag bf70d35 --runzi-gitref main --skip-push
 Deploy with specific OpenQuake and Python versions:
 
 ```bash
-runzi utils deploy-docker \
+runzi utils container \
     --fatjar-tag bf70d35 \
     --runzi-gitref main \
     --oq-version 3.24.0 \
@@ -126,7 +126,7 @@ runzi utils deploy-docker \
 Include the UCERF converter in the image:
 
 ```bash
-runzi utils deploy-docker \
+runzi utils container \
     --fatjar-tag bf70d35 \
     --runzi-gitref main \
     --install-converter
@@ -135,7 +135,7 @@ runzi utils deploy-docker \
 ### Via runzi CLI
 
 ```bash
-runzi utils deploy-docker \
+runzi utils container \
     --fatjar-tag bf70d35 \
     --runzi-gitref main
 ```

--- a/docs/usage/docker/dev_locally.md
+++ b/docs/usage/docker/dev_locally.md
@@ -1,0 +1,56 @@
+# Developing runzi inside the Docker container
+
+Some tasks (OpenQuake hazard, disaggregation) require dependencies baked into the Docker image — Java 11, the OpenSHA fat-jar, and OpenQuake. When working on those tasks you want code changes on the host to take effect immediately, without rebuilding the image.
+
+## 1. Build the dev image (once, or when deps change)
+
+```bash
+runzi utils container --dev \
+  --fatjar-tag <fatjar_tag> \
+  --oq-version <oq_version> \
+  --runzi-gitref <branch-or-commit>
+```
+
+This builds `runzi-build:dev` locally. It does **not** push to ECR or update the AWS Batch job definition. The `FATJAR_TAG`, `OQ_VERSION`, and `PYTHON_VERSION` values from your `.env` are picked up automatically if present.
+
+Rebuild whenever you change a dependency (openquake version, fatjar, nzshm-model, etc.). Pure Python changes to the `runzi/` source do **not** require a rebuild.
+
+## 2. Run with live host source
+
+Add `--docker-dev` to any normal `runzi` invocation. The wrapper automatically bind-mounts your local `runzi/` source over the copy baked into the image, so every Python edit takes effect immediately:
+
+```bash
+runzi --docker-dev hazard oq-hazard /path/to/config.json
+```
+
+The dev image installs runzi as an editable package pointing at `/app/nzshm-runzi`. The wrapper mounts your host repo there, so every import resolves to your live files.
+
+## 3. Debugging with pdb
+
+Drop a `breakpoint()` anywhere in the host source, then run the command above. `--docker-dev` allocates an interactive TTY so pdb takes over the terminal when the breakpoint is hit.
+
+For an interactive shell instead of a one-shot command:
+
+```bash
+runzi --docker-shell --docker-dev
+```
+
+(Combining `--docker-shell` and `--docker-dev` drops into bash with the dev image and source mount active.)
+
+Or equivalently with a raw docker run:
+
+```bash
+docker run --rm -it --entrypoint bash \
+  -v /path/to/nzshm-runzi:/app/nzshm-runzi \
+  ... (same volumes and --env-file) \
+  runzi-build:dev
+```
+
+Then inside the container: `runzi hazard oq-hazard /INPUT_FILES/config.json`.
+
+## Notes
+
+- The bind-mount overrides only the `runzi` package. All other deps (OpenSHA, OpenQuake, Java, nzshm-model) remain as built into the image.
+- `PYTHONDONTWRITEBYTECODE=1` is set in the dev image so the container does not write root-owned `__pycache__/` directories into your host repo.
+- The `.env` file in your working directory is loaded automatically by both the wrapper and runzi itself (via python-dotenv).
+- The source path is auto-derived from `runzi.__file__` so you do not need to specify it — just run `runzi --docker-dev` from any directory.

--- a/docs/usage/docker/dev_locally.md
+++ b/docs/usage/docker/dev_locally.md
@@ -5,7 +5,7 @@ Some tasks (OpenQuake hazard, disaggregation) require dependencies baked into th
 ## 1. Build the dev image (once, or when deps change)
 
 ```bash
-runzi utils container --dev \
+runzi utils docker-build --dev \
   --fatjar-tag <fatjar_tag> \
   --oq-version <oq_version> \
   --runzi-gitref <branch-or-commit>

--- a/docs/usage/docker/run_locally.md
+++ b/docs/usage/docker/run_locally.md
@@ -1,60 +1,90 @@
 # Running the docker container locally
 
-Users may want to run the docker container locally so that all dependencies (OpenSHA and OpenQuake) are available. If you are not running jobs locally, only spawning them from your local machine, it is not necessary to run runzi in the container as the dependencies will be available on the cloud container.
+Users may want to run the docker container locally so that all dependencies (OpenSHA and OpenQuake) are available. If you are not running jobs locally — only spawning them from your local machine — it is not necessary to run runzi in the container, as the dependencies will be available on the cloud container.
 
-In the following commands, replace the docker image (e.g., `461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi-openquake:latest`) with the image use wish to use. 
+## Using the `--docker` flag (recommended)
 
-Replace `[COMMAND] [COMMAND] [OPTIONS]` with the `runzi` commands you wish to run, e.g. `inversion crustal /INPUT_FILES/crustal_inversion.json`.
-
-## Notes:
-- You must map your AWS credentials to the container `-v $HOME/.aws/credentials:/home/openquake/.aws/credentials:ro`
-- In these examples we have mapped a directory containing input JSON files to `/INPUT_FILES` into the container.
-
-## If using a local realization dataset for OpenQuake
-
-You must map `NZSHM22_THS_RLZ_DB` to the `/THS` directory in the docker so that data can be written to it.
+The easiest way to run a command inside the container is to add `--docker` to any normal `runzi` invocation:
 
 ```console
-docker run --entrypoint runzi \
--v $HOME/.aws/credentials:/root/.aws/credentials:ro \
--v <path to input files>:/INPUT_FILES
--v $NZSHM22_THS_RLZ_DB:/THS \
--e THS_DATASET_AGGR_URI \
--e AWS_PROFILE \
--e NZSHM22_TOSHI_S3_URL \
--e NZSHM22_TOSHI_API_URL \
--e NZSHM22_TOSHI_API_KEY \
--e NZSHM22_RUNZI_ECR_DIGEST \
-runzi-build:latest [COMMAND] [COMMAND] [OPTIONS]
+runzi --docker hazard oq-hazard /path/to/config.json
+runzi --docker inversion crustal /path/to/config.json
 ```
 
-## If using an S3 realization dataset for OpenQuake
+The wrapper automatically:
 
-In this case you must set `NZSHM22_THS_RLZ_DB` to the S3 URI.
+- Pulls the image from ECR if it is not present locally (no manual `docker login` needed).
+- Mounts the config file's parent directory at `/INPUT_FILES` inside the container (all subdirectories are included, so configs that reference other files via relative paths work without extra flags).
+- Mounts your AWS credentials read-only.
+- Mounts your local THS dataset directories (from `$NZSHM22_THS_RLZ_DB` and `$NZSHM22_THS_DISAGG_RLZ_DB`) if they are local paths. If they are `s3://` URIs they are forwarded as environment variables instead.
+- Runs the container as your host user ID so output files are owned by you, not root.
+- Forwards all `NZSHM22_*`, `AWS_PROFILE`, `AWS_REGION`, and `THS_DATASET_AGGR_URI` environment variables from your `.env` file.
+
+### Prerequisites
+
+- Docker installed and running.
+- A `.env` file in your working directory (or the relevant env vars exported in your shell) — the same file you use for normal runzi runs.
+- AWS credentials at `~/.aws/credentials`.
+
+### Convention for config files that reference other files
+
+When using `--docker`, config files may only reference other files via **relative paths** to the same directory or a subdirectory. For example, if your config lives at `/data/jobs/run1/config.json` and references `../srm.zip`, that reference will not be accessible inside the container. Move `srm.zip` into `/data/jobs/run1/` or a subdirectory.
+
+### Interactive shell
+
+To drop into a bash shell inside the container with all mounts ready (useful for running multiple commands or debugging):
 
 ```console
-docker run --entrypoint runzi \
--v $HOME/.aws/credentials:/root/.aws/credentials:ro \
--v <path to input files>:/INPUT_FILES
--e NZSHM22_THS_RLZ_DB \
--e THS_DATASET_AGGR_URI \
--e AWS_PROFILE \
--e NZSHM22_TOSHI_S3_URL \
--e NZSHM22_TOSHI_API_URL \
--e NZSHM22_TOSHI_API_KEY \
--e NZSHM22_RUNZI_ECR_DIGEST \
-runzi-build:latest [COMMAND] [COMMAND] [OPTIONS]
+runzi --docker-shell
 ```
 
-## Environment file
+### Available `--docker-*` flags
 
-Optionally, environment variables can be passed to the container using an file:
+| Flag | Purpose |
+|---|---|
+| `--docker` | Route the command through a local Docker container |
+| `--docker-dev` | Use the dev image with editable host source; implies `--docker` |
+| `--docker-image TEXT` | Override the image tag or full ECR URI; implies `--docker` |
+| `--docker-shell` | Drop into an interactive bash session; implies `--docker` |
+| `--docker-dry-run` | Print the docker command without running it; implies `--docker` |
+
+## Fallback: raw `docker run`
+
+If you cannot install runzi on the host, you can still run the container directly. Replace `[COMMAND] [SUBCOMMAND] [OPTIONS]` with the runzi command you wish to run (e.g. `hazard oq-hazard /INPUT_FILES/config.json`).
+
+### With a local THS dataset
 
 ```console
-docker run --entrypoint runzi \
--v <path to input files>:/INPUT_FILES \
--v $HOME/.aws/credentials:/root/.aws/credentials:ro \
--v $NZSHM22_THS_RLZ_DB:/THS \
---env-file .my.env
-461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi-openquake:latest [COMMAND] [COMMAND] [OPTIONS]
+docker run --rm --user "$(id -u):$(id -g)" --entrypoint runzi \
+  -v <path to input files>:/INPUT_FILES:ro \
+  -v $HOME/.aws/credentials:/aws-credentials:ro \
+  -v $NZSHM22_THS_RLZ_DB:/THS/HAZARD \
+  -v $NZSHM22_THS_DISAGG_RLZ_DB:/THS/DISAGG \
+  -e AWS_SHARED_CREDENTIALS_FILE=/aws-credentials \
+  -e AWS_PROFILE \
+  -e NZSHM22_TOSHI_S3_URL \
+  -e NZSHM22_TOSHI_API_URL \
+  -e NZSHM22_TOSHI_API_KEY \
+  -e NZSHM22_RUNZI_ECR_DIGEST \
+  runzi-build:latest [COMMAND] [SUBCOMMAND] [OPTIONS]
+```
+
+### With an S3 THS dataset
+
+Set `NZSHM22_THS_RLZ_DB` and `NZSHM22_THS_DISAGG_RLZ_DB` to `s3://` URIs and omit the `/THS` mounts:
+
+```console
+docker run --rm --user "$(id -u):$(id -g)" --entrypoint runzi \
+  -v <path to input files>:/INPUT_FILES:ro \
+  -v $HOME/.aws/credentials:/aws-credentials:ro \
+  -e AWS_SHARED_CREDENTIALS_FILE=/aws-credentials \
+  -e NZSHM22_THS_RLZ_DB \
+  -e NZSHM22_THS_DISAGG_RLZ_DB \
+  -e THS_DATASET_AGGR_URI \
+  -e AWS_PROFILE \
+  -e NZSHM22_TOSHI_S3_URL \
+  -e NZSHM22_TOSHI_API_URL \
+  -e NZSHM22_TOSHI_API_KEY \
+  -e NZSHM22_RUNZI_ECR_DIGEST \
+  runzi-build:latest [COMMAND] [SUBCOMMAND] [OPTIONS]
 ```

--- a/docs/usage/docker/run_locally.md
+++ b/docs/usage/docker/run_locally.md
@@ -13,7 +13,7 @@ runzi --docker inversion crustal /path/to/config.json
 
 The wrapper automatically:
 
-- Pulls the image from ECR if it is not present locally (no manual `docker login` needed).
+- Pulls the image from ECR if it is not present locally.
 - Mounts the config file's parent directory at `/INPUT_FILES` inside the container (all subdirectories are included, so configs that reference other files via relative paths work without extra flags).
 - Mounts your AWS credentials read-only.
 - Mounts your local THS dataset directories (from `$NZSHM22_THS_RLZ_DB` and `$NZSHM22_THS_DISAGG_RLZ_DB`) if they are local paths. If they are `s3://` URIs they are forwarded as environment variables instead.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
     - Docker:
       - Build and Deploy Container: usage/docker/build_and_deploy_container.md
       - Running the Container Locally: usage/docker/run_locally.md
-    - Inversion, Docker, and AWS: usage/docker/AWS_docker_containers_setup.md
+      - Developing runzi inside the Docker container: usage/docker/dev_locally.md
   - Process:
     - Building the SRM: process/build_srm_for_oq.md
   - Installation: installation.md

--- a/runzi/_oq_runner.py
+++ b/runzi/_oq_runner.py
@@ -1,0 +1,53 @@
+"""OQ-venv-side helper. Executed by /opt/oq-venv/bin/python, NEVER imported from runzi.
+
+This script wraps the OpenQuake UCERF converter. It is bundled inside the runzi
+package directory so it can be located at runtime, but it is only ever executed
+by the oq-venv Python interpreter — never imported from the runzi virtualenv.
+
+openquake.* imports are deferred to function bodies so that syntax-checking or
+accidental import from a venv that lacks OpenQuake does not raise ImportError.
+"""
+import argparse
+import json
+from pathlib import Path
+
+
+def cmd_convert(args):
+    """Run the UCERF -> OpenQuake XML conversion using a JSON config file."""
+    from openquake.converters.ucerf.parsers.sections_geojson import get_multi_fault_source
+    from openquake.hazardlib.sourcewriter import write_source_model
+
+    cfg = json.loads(Path(args.config).read_text())
+    computed = get_multi_fault_source(
+        cfg['src_folder'],
+        cfg['dip_sd'],
+        cfg['strike_sd'],
+        cfg['source_id'],
+        cfg['source_name'],
+        cfg['tectonic_region_type'],
+        cfg['investigation_time'],
+        cfg['prefix'],
+    )
+    write_source_model(
+        cfg['out_file'],
+        [computed],
+        name=cfg['source_name'],
+        investigation_time=cfg['investigation_time'],
+        prefix=cfg['prefix'],
+    )
+
+
+def main():
+    p = argparse.ArgumentParser(description='OpenQuake venv-side helper for nzshm-runzi.')
+    sub = p.add_subparsers(dest='cmd', required=True)
+
+    c = sub.add_parser('convert', help='Convert a UCERF solution folder to an OpenQuake XML source model.')
+    c.add_argument('--config', required=True, help='Path to the JSON config file.')
+    c.set_defaults(func=cmd_convert)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/runzi/_oq_runner.py
+++ b/runzi/_oq_runner.py
@@ -12,12 +12,21 @@ import json
 from pathlib import Path
 
 
-def cmd_convert(args):
-    """Run the UCERF -> OpenQuake XML conversion using a JSON config file."""
+def cmd_convert(args: argparse.Namespace) -> None:
+    """Run UCERF -> OpenQuake XML conversion from a JSON config file.
+
+    Args:
+        args: Parsed CLI args; args.config is the path to the JSON config.
+    """
     from openquake.converters.ucerf.parsers.sections_geojson import get_multi_fault_source
     from openquake.hazardlib.sourcewriter import write_source_model
 
-    cfg = json.loads(Path(args.config).read_text())
+    try:
+        cfg = json.loads(Path(args.config).read_text())
+    except FileNotFoundError as e:
+        raise SystemExit(f'Config file not found: {args.config}') from e
+    except json.JSONDecodeError as e:
+        raise SystemExit(f'Invalid JSON in config: {e}') from e
     computed = get_multi_fault_source(
         cfg['src_folder'],
         cfg['dip_sd'],
@@ -37,7 +46,8 @@ def cmd_convert(args):
     )
 
 
-def main():
+def main() -> None:
+    """Parse CLI args and dispatch to subcommand."""
     p = argparse.ArgumentParser(description='OpenQuake venv-side helper for nzshm-runzi.')
     sub = p.add_subparsers(dest='cmd', required=True)
 

--- a/runzi/automation/local_config.py
+++ b/runzi/automation/local_config.py
@@ -70,3 +70,7 @@ S3_REPORT_BUCKET = os.getenv('NZSHM22_S3_REPORT_BUCKET', "None")
 S3_UPLOAD_WORKERS = int(os.getenv('NZSHM22_S3_UPLOAD_WORKERS', 50))
 
 SPOOF = boolean_env('SPOOF')
+
+# OpenQuake environment settings
+OQ_VENV = os.environ.get('NZSHM22_OQ_VENV')
+OQ_DATADIR = os.environ.get('NZSHM22_OQ_DATADIR')

--- a/runzi/automation/local_config.py
+++ b/runzi/automation/local_config.py
@@ -72,5 +72,5 @@ S3_UPLOAD_WORKERS = int(os.getenv('NZSHM22_S3_UPLOAD_WORKERS', 50))
 SPOOF = boolean_env('SPOOF')
 
 # OpenQuake environment settings
-OQ_VENV = os.environ.get('NZSHM22_OQ_VENV')
-OQ_DATADIR = os.environ.get('NZSHM22_OQ_DATADIR')
+OQ_VENV = os.getenv('NZSHM22_OQ_VENV')
+OQ_DATADIR = os.getenv('NZSHM22_OQ_DATADIR')

--- a/runzi/automation/opensha_task_factory.py
+++ b/runzi/automation/opensha_task_factory.py
@@ -123,7 +123,6 @@ class OpenshaTaskFactory:
             f"export JAVA_CLASSPATH={self._app_jar_path}\n"
             "export CLASSNAME=nz.cri.gns.NZSHM22.opensha.util.NZSHM22_PythonGateway\n"
             f"export NZSHM22_APP_PORT={self._next_port}\n"
-            f"cd {self._root_path}\n"
             f"java -Xms{self._jvm_heap_start_gb}G -Xmx{self._jvm_heap_max_gb}G"
             f" -classpath ${{JAVA_CLASSPATH}} ${{CLASSNAME}} > "
             f"{self._working_path}/java_app.{self._next_port}.log &\n"

--- a/runzi/aws/aws.py
+++ b/runzi/aws/aws.py
@@ -191,6 +191,7 @@ def get_ecs_job_config(
                 {"name": "NZSHM22_AWS_JAVA_THREADS", "value": str(int(vcpu))},
                 {"name": "NZSHM22_TOSHI_S3_URL", "value": toshi_s3_url},
                 {"name": "NZSHM22_TOSHI_API_URL", "value": toshi_api_url},
+                {"name": "NZSHM22_TOSHI_API_ENABLED", "value": "1"},
                 {"name": "NZSHM22_S3_REPORT_BUCKET", "value": toshi_report_bucket},
                 {"name": "NZSHM22_RUNZI_ECR_DIGEST", "value": ecr_digest},
                 {"name": "NZSHM22_THS_RLZ_DB", "value": ths_rlz_db},

--- a/runzi/cli/build_and_deploy_container.py
+++ b/runzi/cli/build_and_deploy_container.py
@@ -1,6 +1,5 @@
 """Deploy docker image to AWS ECR and update Batch job definition."""
 
-import os
 import subprocess
 from pathlib import Path
 
@@ -10,16 +9,6 @@ from dotenv import load_dotenv
 from rich import print as rich_print
 
 load_dotenv()
-
-DEFAULTS = {
-    "python_version": os.environ.get("PYTHON_VERSION", "3.11"),
-    "oq_version": os.environ.get("OQ_VERSION", "3.23.4"),
-    "region": os.environ.get("AWS_REGION", "us-east-1"),
-    "aws_account_id": os.environ.get("AWS_ACCOUNT_ID", "461564345538"),
-    "ecr_repo": os.environ.get("ECR_REPO", "nzshm22/runzi"),
-    "job_definition": os.environ.get("JOB_DEFINITION", "runzi_32GB_8VCPU_JD"),
-    "dockerfile": os.environ.get("DOCKERFILE", "docker/Dockerfile"),
-}
 
 app = typer.Typer()
 
@@ -46,6 +35,7 @@ def build_docker_image(
     runzi_gitref: str,
     oq_version: str,
     install_converter: bool = False,
+    dev: bool = False,
     cwd: Path | None = None,
 ) -> str:
     """Build Docker image and return the full git hash used."""
@@ -55,6 +45,8 @@ def build_docker_image(
 
     dockerfile_path = Path(dockerfile)
     dockerfile_dir = dockerfile_path.parent.resolve()
+
+    image_tag = "runzi-build:dev" if dev else "runzi-build:latest"
 
     build_cmd = [
         "docker",
@@ -73,7 +65,9 @@ def build_docker_image(
     ]
     if install_converter:
         build_cmd.extend(["--build-arg", "INSTALL_CONVERTER=Y"])
-    build_cmd.extend(["-t", "runzi-build:latest", "."])
+    if dev:
+        build_cmd.extend(["--target", "dev"])
+    build_cmd.extend(["-t", image_tag, "."])
 
     print("Building Docker image...")
     print(f"  Dockerfile: {dockerfile}")
@@ -82,6 +76,9 @@ def build_docker_image(
     print(f"  FATJAR_TAG: {fatjar_tag}")
     print(f"  RUNZI_GITREF: {runzi_gitref} -> {git_hash}")
     print(f"  OQ_VERSION: {oq_version}")
+    print(f"  Image tag: {image_tag}")
+    if dev:
+        print("  Target: dev (editable install, local-only)")
 
     result = subprocess.run(build_cmd, cwd=dockerfile_dir)
     if result.returncode != 0:
@@ -186,50 +183,27 @@ def update_job_definition(
 
 @app.command()
 def build_and_deploy_container(
-    fatjar_tag: str = typer.Option(
-        default=os.environ.get("FATJAR_TAG"),
-        prompt=True if not os.environ.get("FATJAR_TAG") else False,
-        help="OpenSHA fatjar tag",
-    ),
-    runzi_gitref: str = typer.Option(
-        default=os.environ.get("RUNZI_GITREF"),
-        prompt=True if not os.environ.get("RUNZI_GITREF") else False,
-        help="Git branch, tag, or commit to build",
-    ),
-    python_version: str = typer.Option(
-        default=os.environ.get("PYTHON_VERSION", DEFAULTS["python_version"]),
-        help="Python version",
-    ),
-    oq_version: str = typer.Option(
-        default=os.environ.get("OQ_VERSION", DEFAULTS["oq_version"]),
-        help="OpenQuake version",
-    ),
+    fatjar_tag: str = typer.Option(..., envvar="FATJAR_TAG", prompt=True, help="OpenSHA fatjar tag"),
+    runzi_gitref: str = typer.Option("main", envvar="RUNZI_GITREF", help="Git branch, tag, or commit to build"),
+    python_version: str = typer.Option("3.11", envvar="PYTHON_VERSION", help="Python version"),
+    oq_version: str = typer.Option(..., envvar="OQ_VERSION", prompt=True, help="OpenQuake version"),
     install_converter: bool = typer.Option(default=False, help="Set to install UCERF converter"),
-    region: str = typer.Option(
-        default=os.environ.get("AWS_REGION", DEFAULTS["region"]),
-        help="AWS region",
+    dev: bool = typer.Option(
+        default=False, help="Build dev image (editable install, local-only; skips ECR push and job update)"
     ),
-    aws_account_id: str = typer.Option(
-        default=os.environ.get("AWS_ACCOUNT_ID", DEFAULTS["aws_account_id"]),
-        help="AWS account ID",
-    ),
-    ecr_repo: str = typer.Option(
-        default=os.environ.get("ECR_REPO", DEFAULTS["ecr_repo"]),
-        help="ECR repository",
-    ),
-    job_definition: str = typer.Option(
-        default=os.environ.get("JOB_DEFINITION", DEFAULTS["job_definition"]),
-        help="Batch job definition",
-    ),
-    dockerfile: str = typer.Option(
-        default=os.environ.get("DOCKERFILE", DEFAULTS["dockerfile"]),
-        help="Path to Dockerfile",
-    ),
+    region: str = typer.Option("us-east-1", envvar="AWS_REGION", help="AWS region"),
+    aws_account_id: str = typer.Option("461564345538", envvar="AWS_ACCOUNT_ID", help="AWS account ID"),
+    ecr_repo: str = typer.Option("nzshm22/runzi", envvar="ECR_REPO", help="ECR repository"),
+    job_definition: str = typer.Option("runzi_32GB_8VCPU_JD", envvar="JOB_DEFINITION", help="Batch job definition"),
+    dockerfile: str = typer.Option("docker/Dockerfile", envvar="DOCKERFILE", help="Path to Dockerfile"),
     skip_build: bool = typer.Option(default=False, help="Skip Docker build"),
     skip_push: bool = typer.Option(default=False, help="Skip ECR push"),
     skip_job_update: bool = typer.Option(default=False, help="Skip job definition update"),
 ):
     """Build runzi-opensha Docker image, push to ECR, update Batch job definition."""
+    if dev:
+        skip_push = True
+        skip_job_update = True
     if skip_push:
         skip_job_update = True
 
@@ -241,6 +215,7 @@ def build_and_deploy_container(
     print(f"  runzi_gitref: {runzi_gitref}")
     print(f"  oq_version: {oq_version}")
     print(f"  install_converter: {install_converter}")
+    print(f"  dev: {dev}")
     print(f"  region: {region}")
     print(f"  aws_account_id: {aws_account_id}")
     print(f"  ecr_repo: {ecr_repo}")
@@ -259,9 +234,11 @@ def build_and_deploy_container(
         rich_print(f"[red]Error: Dockerfile not found: {dockerfile_path}[/red]")
         raise typer.Exit(1)
 
+    local_image_tag = "runzi-build:dev" if dev else "runzi-build:latest"
+
     try:
         if skip_build:
-            print("Skipping build (using existing runzi-build:latest)")
+            print(f"Skipping build (using existing {local_image_tag})")
             git_hash = get_git_hash(runzi_gitref)
         else:
             git_hash = build_docker_image(
@@ -271,11 +248,11 @@ def build_and_deploy_container(
                 runzi_gitref,
                 oq_version,
                 install_converter,
+                dev,
             )
 
-        ecr_login(region, aws_account_id)
-
         if not skip_push:
+            ecr_login(region, aws_account_id)
             image_uri, image_digest = tag_and_push_image(
                 ecr_repo,
                 aws_account_id,
@@ -286,7 +263,7 @@ def build_and_deploy_container(
                 oq_version,
             )
         else:
-            image_uri, image_digest = "<skipped>", "sha256:skipped"
+            image_uri, image_digest = local_image_tag, "sha256:skipped"
 
         if not skip_job_update:
             new_job_def_arn = update_job_definition(
@@ -303,8 +280,9 @@ def build_and_deploy_container(
         ]
         completed = [name for name, done in stages if done]
         rich_print(f"[bold green]Completed {', '.join(completed)}![/bold green]")
-        print(f"Image URI: {image_uri}")
-        print(f"Image digest: {image_digest}")
+        print(f"Image: {local_image_tag if dev else image_uri}")
+        if not dev:
+            print(f"Image digest: {image_digest}")
         if not skip_job_update:
             print(f"Job Definition: {new_job_def_arn}")
         print()

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -309,7 +309,7 @@ def run_in_docker(
 
     if dry_run:
         rich_print('[bold]docker command (dry run):[/bold]')
-        rich_print(' \\\n  '.join(cmd))
+        print(' \\\n  '.join(cmd))
         return 0
 
     result = subprocess.run(cmd, check=False)

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -106,7 +106,8 @@ def build_docker_cmd(
     """Build the docker run argument list. Does not call any subprocess."""
     cmd: list[str] = ['docker', 'run', '--rm']
 
-    cmd += ['--user', f'{os.getuid()}:{os.getgid()}']
+    if hasattr(os, 'getuid'):  # POSIX only — Docker Desktop on Windows handles UID mapping via WSL2
+        cmd += ['--user', f'{os.getuid()}:{os.getgid()}']
 
     if interactive or shell or dev:
         cmd += ['--interactive', '--tty']

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -79,7 +79,7 @@ def rewrite_file_args(args: list[str], file_args: list[Path], ancestor: Path) ->
     for arg in args:
         if arg in file_map:
             rel = file_map[arg].relative_to(ancestor)
-            result.append(f'{_INPUT_FILES}/{rel}')
+            result.append(f'{_INPUT_FILES}/{rel.as_posix()}')
         else:
             result.append(arg)
     return result

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -107,7 +107,7 @@ def build_docker_cmd(
     cmd: list[str] = ['docker', 'run', '--rm']
 
     if hasattr(os, 'getuid'):  # POSIX only — Docker Desktop on Windows handles UID mapping via WSL2
-        cmd += ['--user', f'{os.getuid()}:{os.getgid()}']
+        cmd += ['--user', f'{os.getuid()}:{os.getgid()}']  # type: ignore
 
     if interactive or shell or dev:
         cmd += ['--interactive', '--tty']

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -220,6 +220,10 @@ def run_in_docker(
     if ths_disagg_extra:
         env_vars.update(ths_disagg_extra)
 
+    # Host UID is not in the container's /etc/passwd, so getpass.getuser() falls back
+    # to pwd.getpwuid() and fails.  Ensure USER is set so the env-var path is taken.
+    env_vars.setdefault('USER', os.environ.get('USER', 'runzi'))
+
     aws_credentials = Path.home() / '.aws' / 'credentials'
     if not aws_credentials.exists():
         rich_print(f'[yellow]Warning: AWS credentials not found at {aws_credentials}[/yellow]')
@@ -234,10 +238,16 @@ def run_in_docker(
     rewritten_args = inner_args
 
     if not shell and inner_args:
-        file_args = find_file_args(inner_args)
+        # Resolve any args that are existing files to absolute paths upfront.
+        # Docker mount sources must be absolute; a relative path like
+        # `INPUT_FILES/foo.json` is otherwise treated as a named volume.
+        normalized = [str(Path(arg).resolve()) if Path(arg).is_file() else arg for arg in inner_args]
+        file_args = find_file_args(normalized)
         if file_args:
             input_dir = common_ancestor(file_args)
-            rewritten_args = rewrite_file_args(inner_args, file_args, input_dir)
+            rewritten_args = rewrite_file_args(normalized, file_args, input_dir)
+        else:
+            rewritten_args = inner_args
     elif shell:
         input_dir = Path.cwd()
 

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -172,6 +172,8 @@ def _maybe_pull(image: str) -> None:
     region = os.environ.get('AWS_REGION', _DEFAULT_AWS_REGION)
     account = os.environ.get('AWS_ACCOUNT_ID', _DEFAULT_AWS_ACCOUNT)
     repo = os.environ.get('ECR_REPO', _DEFAULT_ECR_REPO)
+    if ":" not in image:  # guard againt no tag
+        image += ":"
     ecr_image = f'{account}.dkr.ecr.{region}.amazonaws.com/{repo}:{image.split(":")[-1]}'
     rich_print(f'[yellow]Image {image!r} not found locally — pulling {ecr_image} from ECR[/yellow]')
     _ecr_login(region, account)

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -1,0 +1,270 @@
+"""Helpers for routing a runzi invocation through a local Docker container."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from rich import print as rich_print
+
+load_dotenv()
+
+_ENV_PASSTHROUGH = frozenset(
+    [
+        'AWS_PROFILE',
+        'AWS_REGION',
+        'THS_DATASET_AGGR_URI',
+    ]
+)
+_ENV_PREFIX_PASSTHROUGH = 'NZSHM22_'
+
+_DEFAULT_IMAGE = 'runzi-build:latest'
+_DEFAULT_DEV_IMAGE = 'runzi-build:dev'
+_DEFAULT_ECR_REPO = 'nzshm22/runzi'
+_DEFAULT_AWS_ACCOUNT = '461564345538'
+_DEFAULT_AWS_REGION = 'us-east-1'
+
+_INPUT_FILES = '/INPUT_FILES'
+_AWS_CREDS_CONTAINER = '/aws-credentials'
+
+
+# ── Pure path helpers ─────────────────────────────────────────────────────────
+
+
+def find_file_args(args: list[str]) -> list[Path]:
+    """Return any args that are existing files on the host."""
+    found = []
+    for arg in args:
+        p = Path(arg)
+        if p.is_file():
+            found.append(p)
+    return found
+
+
+def common_ancestor(paths: list[Path]) -> Path:
+    """Return the deepest directory that contains all paths."""
+    if len(paths) == 1:
+        return paths[0].parent
+    return Path(os.path.commonpath([str(p.parent) for p in paths]))
+
+
+def rewrite_file_args(args: list[str], file_args: list[Path], ancestor: Path) -> list[str]:
+    """Replace host file paths in args with their /INPUT_FILES equivalents."""
+    file_map = {str(f): f for f in file_args}
+    result = []
+    for arg in args:
+        if arg in file_map:
+            rel = file_map[arg].relative_to(ancestor)
+            result.append(f'{_INPUT_FILES}/{rel}')
+        else:
+            result.append(arg)
+    return result
+
+
+# ── Command assembly ──────────────────────────────────────────────────────────
+
+
+def build_docker_cmd(
+    *,
+    inner_args: list[str],
+    image: str,
+    dev: bool,
+    shell: bool,
+    aws_credentials: Path,
+    ths_hazard: Path | None,
+    ths_disagg: Path | None,
+    env_vars: dict[str, str],
+    input_dir: Path | None = None,
+    runzi_source: Path | None = None,
+    interactive: bool = False,
+) -> list[str]:
+    """Build the docker run argument list. Does not call any subprocess."""
+    cmd: list[str] = ['docker', 'run', '--rm']
+
+    cmd += ['--user', f'{os.getuid()}:{os.getgid()}']
+
+    if interactive or shell or dev:
+        cmd += ['--interactive', '--tty']
+
+    entrypoint = 'bash' if shell else 'runzi'
+    cmd += ['--entrypoint', entrypoint]
+
+    if input_dir is not None:
+        cmd += ['-v', f'{input_dir}:{_INPUT_FILES}:ro']
+
+    cmd += ['-v', f'{aws_credentials}:{_AWS_CREDS_CONTAINER}:ro']
+
+    if ths_hazard is not None:
+        cmd += ['-v', f'{ths_hazard}:/THS/HAZARD']
+
+    if ths_disagg is not None:
+        cmd += ['-v', f'{ths_disagg}:/THS/DISAGG']
+
+    if dev and runzi_source is not None:
+        cmd += ['-v', f'{runzi_source}:/app/nzshm-runzi']
+
+    cmd += ['-e', f'AWS_SHARED_CREDENTIALS_FILE={_AWS_CREDS_CONTAINER}']
+    for key, value in env_vars.items():
+        cmd += ['-e', f'{key}={value}']
+
+    cmd.append(image)
+
+    if not shell:
+        cmd.extend(inner_args)
+
+    return cmd
+
+
+# ── Image helpers ─────────────────────────────────────────────────────────────
+
+
+def _image_exists_locally(image: str) -> bool:
+    result = subprocess.run(
+        ['docker', 'image', 'inspect', image],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _ecr_login(region: str, aws_account_id: str) -> None:
+    from runzi.cli.build_and_deploy_container import ecr_login
+
+    ecr_login(region, aws_account_id)
+
+
+def _resolve_image(dev: bool, image_override: str | None) -> str:
+    if image_override:
+        return image_override
+    return _DEFAULT_DEV_IMAGE if dev else _DEFAULT_IMAGE
+
+
+def _maybe_pull(image: str) -> None:
+    if _image_exists_locally(image):
+        return
+    region = os.environ.get('AWS_REGION', _DEFAULT_AWS_REGION)
+    account = os.environ.get('AWS_ACCOUNT_ID', _DEFAULT_AWS_ACCOUNT)
+    repo = os.environ.get('ECR_REPO', _DEFAULT_ECR_REPO)
+    ecr_image = f'{account}.dkr.ecr.{region}.amazonaws.com/{repo}:{image.split(":")[-1]}'
+    rich_print(f'[yellow]Image {image!r} not found locally — pulling {ecr_image} from ECR[/yellow]')
+    _ecr_login(region, account)
+    subprocess.run(['docker', 'pull', ecr_image], check=True)
+    subprocess.run(['docker', 'tag', ecr_image, image], check=True)
+
+
+# ── Env resolution ────────────────────────────────────────────────────────────
+
+
+def _collect_env_vars(extra: dict[str, str]) -> dict[str, str]:
+    """Collect env vars to forward, from the current process environment."""
+    result: dict[str, str] = {}
+    for key, value in os.environ.items():
+        if key.startswith(_ENV_PREFIX_PASSTHROUGH) or key in _ENV_PASSTHROUGH:
+            result[key] = value
+    result.update(extra)
+    return result
+
+
+def _resolve_ths(env_key: str) -> tuple[Path | None, dict[str, str]]:
+    """Return (host_path_or_None, extra_env_to_forward)."""
+    val = os.environ.get(env_key, '')
+    if not val:
+        return None, {}
+    if val.startswith('s3://'):
+        return None, {env_key: val}
+    return Path(val), {}
+
+
+# ── Main entry point ──────────────────────────────────────────────────────────
+
+
+def run_in_docker(
+    inner_args: list[str],
+    *,
+    dev: bool = False,
+    image: str | None = None,
+    shell: bool = False,
+    dry_run: bool = False,
+) -> int:
+    """Run a runzi invocation inside a local Docker container.
+
+    Returns the container exit code (0 on success).
+    """
+    image_tag = _resolve_image(dev, image)
+
+    if not dev:
+        try:
+            _maybe_pull(image_tag)
+        except subprocess.CalledProcessError as exc:
+            rich_print(f'[red]Failed to pull image: {exc}[/red]')
+            return 1
+    elif not _image_exists_locally(image_tag):
+        rich_print(
+            f'[red]Dev image {image_tag!r} not found. Build it first with:[/red]\n  runzi utils container --dev ...'
+        )
+        return 1
+
+    ths_hazard, ths_hazard_extra = _resolve_ths('NZSHM22_THS_RLZ_DB')
+    ths_disagg, ths_disagg_extra = _resolve_ths('NZSHM22_THS_DISAGG_RLZ_DB')
+
+    extra_env: dict[str, str] = {}
+    extra_env.update(ths_hazard_extra)
+    extra_env.update(ths_disagg_extra)
+
+    env_vars = _collect_env_vars(extra_env)
+    # Remove THS vars from forwarded env if they're host paths (image already has defaults)
+    env_vars.pop('NZSHM22_THS_RLZ_DB', None)
+    env_vars.pop('NZSHM22_THS_DISAGG_RLZ_DB', None)
+    if ths_hazard_extra:
+        env_vars.update(ths_hazard_extra)
+    if ths_disagg_extra:
+        env_vars.update(ths_disagg_extra)
+
+    aws_credentials = Path.home() / '.aws' / 'credentials'
+    if not aws_credentials.exists():
+        rich_print(f'[yellow]Warning: AWS credentials not found at {aws_credentials}[/yellow]')
+
+    runzi_source: Path | None = None
+    if dev:
+        import runzi
+
+        runzi_source = Path(runzi.__file__).resolve().parents[1]
+
+    input_dir: Path | None = None
+    rewritten_args = inner_args
+
+    if not shell and inner_args:
+        file_args = find_file_args(inner_args)
+        if file_args:
+            input_dir = common_ancestor(file_args)
+            rewritten_args = rewrite_file_args(inner_args, file_args, input_dir)
+    elif shell:
+        input_dir = Path.cwd()
+
+    interactive = shell or dev
+
+    cmd = build_docker_cmd(
+        inner_args=rewritten_args,
+        image=image_tag,
+        dev=dev,
+        shell=shell,
+        aws_credentials=aws_credentials,
+        ths_hazard=ths_hazard,
+        ths_disagg=ths_disagg,
+        env_vars=env_vars,
+        input_dir=input_dir,
+        runzi_source=runzi_source,
+        interactive=interactive,
+    )
+
+    if dry_run:
+        rich_print('[bold]docker command (dry run):[/bold]')
+        rich_print(' \\\n  '.join(cmd))
+        return 0
+
+    result = subprocess.run(cmd, check=False)
+    return result.returncode
+
+
+if __name__ == '__main__':
+    sys.exit(run_in_docker(sys.argv[1:]))

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -240,7 +240,7 @@ def run_in_docker(
             return 1
     elif not _image_exists_locally(image_tag):
         rich_print(
-            f'[red]Dev image {image_tag!r} not found. Build it first with:[/red]\n  runzi utils container --dev ...'
+            f'[red]Dev image {image_tag!r} not found. Build it first with:[/red]\n  runzi utils docker-build --dev ...'
         )
         return 1
 

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -17,7 +17,29 @@ _ENV_PASSTHROUGH = frozenset(
         'THS_DATASET_AGGR_URI',
     ]
 )
-_ENV_PREFIX_PASSTHROUGH = 'NZSHM22_'
+
+# NZSHM22_* env vars that should be forwarded from host to container.
+# Image-set path vars (NZSHM22_SCRIPT_WORK_PATH, OPENSHA_*, FATJAR, OQ_*, THS_*)
+# are intentionally omitted — the image provides container-side defaults and the
+# wrapper mounts host directories at those paths when applicable
+# (THS via _resolve_ths, work-path via _resolve_work_path).
+_ENV_FORWARDED_NZSHM_VARS: frozenset[str] = frozenset(
+    [
+        'NZSHM22_TOSHI_API_ENABLED',
+        'NZSHM22_TOSHI_API_URL',
+        'NZSHM22_TOSHI_API_KEY',
+        'NZSHM22_TOSHI_S3_URL',
+        'NZSHM22_RUNZI_ECR_DIGEST',
+        'NZSHM22_SCRIPT_WORKER_POOL_SIZE',
+        'NZSHM22_SCRIPT_JVM_HEAP_START',
+        'NZSHM22_SCRIPT_CLUSTER_MODE',
+        'NZSHM22_BUILD_PLOTS',
+        'NZSHM22_REPORT_LEVEL',
+        'NZSHM22_HACK_FAULT_MODEL',
+        'NZSHM22_S3_REPORT_BUCKET',
+        'NZSHM22_S3_UPLOAD_WORKERS',
+    ]
+)
 
 _DEFAULT_IMAGE = 'runzi-build:latest'
 _DEFAULT_DEV_IMAGE = 'runzi-build:dev'
@@ -27,6 +49,7 @@ _DEFAULT_AWS_REGION = 'us-east-1'
 
 _INPUT_FILES = '/INPUT_FILES'
 _AWS_CREDS_CONTAINER = '/aws-credentials'
+_WORK_PATH_CONTAINER = '/WORKING'
 
 
 # ── Pure path helpers ─────────────────────────────────────────────────────────
@@ -78,6 +101,7 @@ def build_docker_cmd(
     input_dir: Path | None = None,
     runzi_source: Path | None = None,
     interactive: bool = False,
+    work_path: Path | None = None,
 ) -> list[str]:
     """Build the docker run argument list. Does not call any subprocess."""
     cmd: list[str] = ['docker', 'run', '--rm']
@@ -94,6 +118,9 @@ def build_docker_cmd(
         cmd += ['-v', f'{input_dir}:{_INPUT_FILES}:ro']
 
     cmd += ['-v', f'{aws_credentials}:{_AWS_CREDS_CONTAINER}:ro']
+
+    if work_path is not None:
+        cmd += ['-v', f'{work_path}:{_WORK_PATH_CONTAINER}']
 
     if ths_hazard is not None:
         cmd += ['-v', f'{ths_hazard}:/THS/HAZARD']
@@ -159,7 +186,7 @@ def _collect_env_vars(extra: dict[str, str]) -> dict[str, str]:
     """Collect env vars to forward, from the current process environment."""
     result: dict[str, str] = {}
     for key, value in os.environ.items():
-        if key.startswith(_ENV_PREFIX_PASSTHROUGH) or key in _ENV_PASSTHROUGH:
+        if key in _ENV_FORWARDED_NZSHM_VARS or key in _ENV_PASSTHROUGH:
             result[key] = value
     result.update(extra)
     return result
@@ -173,6 +200,19 @@ def _resolve_ths(env_key: str) -> tuple[Path | None, dict[str, str]]:
     if val.startswith('s3://'):
         return None, {env_key: val}
     return Path(val), {}
+
+
+def _resolve_work_path() -> Path | None:
+    """Return the host work path to mount at /WORKING, or None if unset.
+
+    Creates the directory if it doesn't exist so Docker doesn't auto-create it as root.
+    """
+    val = os.environ.get('NZSHM22_SCRIPT_WORK_PATH', '')
+    if not val:
+        return None
+    p = Path(val).expanduser()
+    p.mkdir(parents=True, exist_ok=True)
+    return p
 
 
 # ── Main entry point ──────────────────────────────────────────────────────────
@@ -206,19 +246,16 @@ def run_in_docker(
 
     ths_hazard, ths_hazard_extra = _resolve_ths('NZSHM22_THS_RLZ_DB')
     ths_disagg, ths_disagg_extra = _resolve_ths('NZSHM22_THS_DISAGG_RLZ_DB')
+    work_path = _resolve_work_path()
 
     extra_env: dict[str, str] = {}
     extra_env.update(ths_hazard_extra)
     extra_env.update(ths_disagg_extra)
 
+    # _collect_env_vars uses an explicit allowlist for NZSHM22_* vars, so image-set
+    # path vars (THS, SCRIPT_WORK_PATH, OQ_*, OPENSHA_*, etc.) are never forwarded.
+    # THS s3:// values are re-added via extra_env after the allowlist pass.
     env_vars = _collect_env_vars(extra_env)
-    # Remove THS vars from forwarded env if they're host paths (image already has defaults)
-    env_vars.pop('NZSHM22_THS_RLZ_DB', None)
-    env_vars.pop('NZSHM22_THS_DISAGG_RLZ_DB', None)
-    if ths_hazard_extra:
-        env_vars.update(ths_hazard_extra)
-    if ths_disagg_extra:
-        env_vars.update(ths_disagg_extra)
 
     # Host UID is not in the container's /etc/passwd, so getpass.getuser() falls back
     # to pwd.getpwuid() and fails.  Ensure USER is set so the env-var path is taken.
@@ -265,6 +302,7 @@ def run_in_docker(
         input_dir=input_dir,
         runzi_source=runzi_source,
         interactive=interactive,
+        work_path=work_path,
     )
 
     if dry_run:

--- a/runzi/cli/runzi_cli.py
+++ b/runzi/cli/runzi_cli.py
@@ -2,7 +2,9 @@
 
 from typing import Annotated
 
+import click
 import typer
+from typer.core import TyperGroup
 
 from runzi.automation import local_config
 from runzi.automation.local_config import ClusterModeEnum
@@ -16,7 +18,50 @@ from runzi.cli import (
     utils_cli,
 )
 
-app = typer.Typer(help="The NZ NSHM runzi CLI.", no_args_is_help=True)
+# ── Arg capture helpers ───────────────────────────────────────────────────────
+
+_DOCKER_BOOL_FLAGS: frozenset[str] = frozenset(
+    ['--docker', '--docker-dev', '--docker-shell', '--docker-dry-run']
+)
+_DOCKER_VALUE_FLAGS: frozenset[str] = frozenset(['--docker-image'])
+
+
+def _strip_docker_flags(args: list[str]) -> list[str]:
+    """Remove --docker-* flags (and their values) from a raw argv list."""
+    result: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in _DOCKER_BOOL_FLAGS:
+            pass  # drop boolean flag
+        elif arg in _DOCKER_VALUE_FLAGS:
+            i += 2  # drop --flag VALUE pair
+            continue
+        elif any(arg.startswith(f'{f}=') for f in _DOCKER_VALUE_FLAGS):
+            pass  # drop --flag=value form
+        else:
+            result.append(arg)
+        i += 1
+    return result
+
+
+class _ArgsCapturingGroup(TyperGroup):
+    """Typer Group subclass that stores the raw pre-parse args in ctx.meta.
+
+    Click's Group.invoke() clears ctx.args and ctx.protected_args before
+    invoking the callback, so the callback cannot recover the subcommand name
+    and its arguments from those attributes.  Capturing the args here, before
+    Click's own processing, is the only reliable interception point.
+    """
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        ctx.meta['_raw_args'] = list(args)
+        return super().parse_args(ctx, args)
+
+
+# ── Typer app ─────────────────────────────────────────────────────────────────
+
+app = typer.Typer(help="The NZ NSHM runzi CLI.", no_args_is_help=True, cls=_ArgsCapturingGroup)
 
 
 @app.callback(invoke_without_command=True)
@@ -57,7 +102,8 @@ def main_callback(
 
     use_docker = docker or docker_dev or docker_shell or docker_dry_run or (docker_image is not None)
     if use_docker:
-        inner_args = list(ctx.args)
+        raw_args = ctx.meta.get('_raw_args', [])
+        inner_args = _strip_docker_flags(raw_args)
         exit_code = docker_wrapper.run_in_docker(
             inner_args,
             dev=docker_dev,

--- a/runzi/cli/runzi_cli.py
+++ b/runzi/cli/runzi_cli.py
@@ -6,25 +6,70 @@ import typer
 
 from runzi.automation import local_config
 from runzi.automation.local_config import ClusterModeEnum
-from runzi.cli import hazard_cli, inversion_cli, inversion_post_process_cli, reports_cli, rupture_sets_cli, utils_cli
+from runzi.cli import (
+    docker_wrapper,
+    hazard_cli,
+    inversion_cli,
+    inversion_post_process_cli,
+    reports_cli,
+    rupture_sets_cli,
+    utils_cli,
+)
 
 app = typer.Typer(help="The NZ NSHM runzi CLI.", no_args_is_help=True)
 
 
-# Register a callback so we can add a command line flag (option) to the runzi app
-# (e.g. `runzi inversion --cluster-mode CLUSTER run ...`).
-@app.callback()
-def cluster_mode_callback(
+@app.callback(invoke_without_command=True)
+def main_callback(
+    ctx: typer.Context,
     cluster_mode: Annotated[
         ClusterModeEnum, typer.Option(help="Execution target: LOCAL machine, HPC CLUSTER, or AWS cloud.")
     ] = local_config.DEFAULT_CLUSTER_MODE,
+    docker: Annotated[bool, typer.Option('--docker', help="Run the command inside a local Docker container.")] = False,
+    docker_dev: Annotated[
+        bool,
+        typer.Option(
+            '--docker-dev', help="Run in Docker using the dev image with editable host source mount. Implies --docker."
+        ),
+    ] = False,
+    docker_image: Annotated[
+        str | None,
+        typer.Option('--docker-image', help="Override the Docker image tag or full ECR URI. Implies --docker."),
+    ] = None,
+    docker_shell: Annotated[
+        bool,
+        typer.Option(
+            '--docker-shell', help="Drop into an interactive bash shell inside the container. Implies --docker."
+        ),
+    ] = False,
+    docker_dry_run: Annotated[
+        bool,
+        typer.Option(
+            '--docker-dry-run', help="Print the docker command that would run, without executing it. Implies --docker."
+        ),
+    ] = False,
 ) -> None:
-    """Set the global cluster mode when explicitly provided by the user.
+    """The NZ NSHM runzi CLI.
 
-    local_config.CLUSTER_MODE is used by the build, schedule task, etc. modules. The value of
-    CLUSTER_MODE dictates behavior which is specific to the platform the jobs are run on.
+    Prefix any command with --docker to run it inside a local Docker container instead of natively.
     """
     local_config.CLUSTER_MODE = cluster_mode
+
+    use_docker = docker or docker_dev or docker_shell or docker_dry_run or (docker_image is not None)
+    if use_docker:
+        inner_args = list(ctx.args)
+        exit_code = docker_wrapper.run_in_docker(
+            inner_args,
+            dev=docker_dev,
+            image=docker_image,
+            shell=docker_shell,
+            dry_run=docker_dry_run,
+        )
+        raise typer.Exit(exit_code)
+
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit(0)
 
 
 app.add_typer(inversion_cli.app, name="inversion", help="inversion", no_args_is_help=True)
@@ -33,6 +78,9 @@ app.add_typer(inversion_post_process_cli.app, name="ipp", help="inversion post p
 app.add_typer(rupture_sets_cli.app, name="rupset", help="create rupture sets", no_args_is_help=True)
 app.add_typer(reports_cli.app, name="reports", help="create inversion and rupture set reports", no_args_is_help=True)
 app.add_typer(utils_cli.app, name="utils", help="utilities", no_args_is_help=True)
+
+# backwards-compat alias used by test_cli_cluster_mode
+cluster_mode_callback = main_callback
 
 if __name__ == "__main__":
     app()

--- a/runzi/cli/runzi_cli.py
+++ b/runzi/cli/runzi_cli.py
@@ -125,8 +125,6 @@ app.add_typer(rupture_sets_cli.app, name="rupset", help="create rupture sets", n
 app.add_typer(reports_cli.app, name="reports", help="create inversion and rupture set reports", no_args_is_help=True)
 app.add_typer(utils_cli.app, name="utils", help="utilities", no_args_is_help=True)
 
-# backwards-compat alias used by test_cli_cluster_mode
-cluster_mode_callback = main_callback
 
 if __name__ == "__main__":
     app()

--- a/runzi/cli/utils_cli.py
+++ b/runzi/cli/utils_cli.py
@@ -11,7 +11,7 @@ from runzi.tasks.utils import VALID_ROW, build_manual_index, run_save_file_archi
 
 app = typer.Typer()
 
-app.command("container")(build_and_deploy_container)
+app.command("docker-build")(build_and_deploy_container)
 
 
 @app.command()

--- a/runzi/tasks/oq_hazard/execute_openquake.py
+++ b/runzi/tasks/oq_hazard/execute_openquake.py
@@ -12,12 +12,6 @@ from runzi.automation.local_config import OQ_DATADIR, OQ_VENV, SPOOF, WORK_PATH
 from runzi.automation.toshi_api.openquake_hazard.openquake_hazard_task import HazardTaskType
 from runzi.utils import archive
 
-if not OQ_VENV:
-    raise RuntimeError('NZSHM22_OQ_VENV must be set for OQ tasks')
-if not OQ_DATADIR:
-    raise RuntimeError('NZSHM22_OQ_DATADIR must be set for OQ tasks')
-OQ_BIN = f'{OQ_VENV}/bin/oq'
-
 log = logging.getLogger(__name__)
 
 
@@ -25,6 +19,11 @@ def execute_openquake(
     configfile: str | Path, task_no: int, toshi_task_id: str | None, hazard_task_type: HazardTaskType
 ):
     """Do the actusal openquake work."""
+    if not OQ_VENV:
+        raise RuntimeError('NZSHM22_OQ_VENV must be set for OQ tasks')
+    if not OQ_DATADIR:
+        raise RuntimeError('NZSHM22_OQ_DATADIR must be set for OQ tasks')
+    oq_bin = f'{OQ_VENV}/bin/oq'
     toshi_task_id = toshi_task_id or f"DUMMY{task_no}_toshi_TASK_ID"
     # if not toshi_task_id:
     #     toshi_task_id = f"DUMMY{task_no}_toshi_TASK_ID"
@@ -51,7 +50,7 @@ def execute_openquake(
         # -L /WORKING/examples/18_SWRG_INIT/jobs/BG_unscaled.log
         #
         env = {**os.environ, 'OQ_DATADIR': str(OQ_DATADIR)}
-        cmd = [OQ_BIN, 'engine', '--run', f'{configfile}', '-L', f'{logfile}']
+        cmd = [oq_bin, 'engine', '--run', f'{configfile}', '-L', f'{logfile}']
         log.info('cmd 1: %s', cmd)
         subprocess.run(cmd, env=env)
 
@@ -86,7 +85,7 @@ def execute_openquake(
                     6 |   complete | 2022-03-29 01:12:16 | 35 sites, few periods
                 """
 
-                cmd = [OQ_BIN, 'engine', '--lhc']
+                cmd = [oq_bin, 'engine', '--lhc']
                 p = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env)
                 out, err = p.communicate()
 
@@ -110,7 +109,7 @@ def execute_openquake(
             #  oq engine --export-outputs 12 /WORKING/examples/output/PROD/34-sites-few-CRU+BG
             #  cp /home/openquake/oqdata/calc_12.hdf5 /WORKING/examples/output/PROD
             #
-            cmd = [OQ_BIN, 'engine', '--export-outputs', str(last_task), str(output_path)]
+            cmd = [oq_bin, 'engine', '--export-outputs', str(last_task), str(output_path)]
             log.info('cmd 2: %s', cmd)
             subprocess.check_call(cmd, stdout=subprocess.DEVNULL, env=env)
             oq_result['csv_archive'] = archive(

--- a/runzi/tasks/oq_hazard/execute_openquake.py
+++ b/runzi/tasks/oq_hazard/execute_openquake.py
@@ -12,8 +12,10 @@ from runzi.automation.local_config import OQ_DATADIR, OQ_VENV, SPOOF, WORK_PATH
 from runzi.automation.toshi_api.openquake_hazard.openquake_hazard_task import HazardTaskType
 from runzi.utils import archive
 
-assert OQ_VENV, 'NZSHM22_OQ_VENV must be set'
-assert OQ_DATADIR, 'NZSHM22_OQ_DATADIR must be set'
+if not OQ_VENV:
+    raise RuntimeError('NZSHM22_OQ_VENV must be set for OQ tasks')
+if not OQ_DATADIR:
+    raise RuntimeError('NZSHM22_OQ_DATADIR must be set for OQ tasks')
 OQ_BIN = f'{OQ_VENV}/bin/oq'
 
 log = logging.getLogger(__name__)
@@ -118,7 +120,7 @@ def execute_openquake(
             # clean up export outputs
             shutil.rmtree(output_path)
 
-            OQDATA = Path(str(OQ_DATADIR))
+            OQDATA = Path(OQ_DATADIR)  # type: ignore[arg-type]  # guarded by module-level RuntimeError
 
             hdf5_file = f"calc_{last_task}.hdf5"
             oq_result['hdf5_archive'] = archive(

--- a/runzi/tasks/oq_hazard/execute_openquake.py
+++ b/runzi/tasks/oq_hazard/execute_openquake.py
@@ -52,7 +52,11 @@ def execute_openquake(
         env = {**os.environ, 'OQ_DATADIR': str(OQ_DATADIR)}
         cmd = [oq_bin, 'engine', '--run', f'{configfile}', '-L', f'{logfile}']
         log.info('cmd 1: %s', cmd)
-        subprocess.run(cmd, env=env)
+        result = subprocess.run(cmd, env=env)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f'oq engine --run exited {result.returncode} for task {task_no}; see {logfile}'
+            )
 
         with open(logfile) as logf:
             oq_out = logf.read()

--- a/runzi/tasks/oq_hazard/execute_openquake.py
+++ b/runzi/tasks/oq_hazard/execute_openquake.py
@@ -2,20 +2,19 @@
 
 import io
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
 
+from runzi.automation.local_config import OQ_DATADIR, OQ_VENV, SPOOF, WORK_PATH
 from runzi.automation.toshi_api.openquake_hazard.openquake_hazard_task import HazardTaskType
-
-try:
-    from openquake.commonlib.datastore import get_datadir
-except ImportError:
-    print("openquake not installed, not importing")
-
-from runzi.automation.local_config import SPOOF, WORK_PATH
 from runzi.utils import archive
+
+assert OQ_VENV, 'NZSHM22_OQ_VENV must be set'
+assert OQ_DATADIR, 'NZSHM22_OQ_DATADIR must be set'
+OQ_BIN = f'{OQ_VENV}/bin/oq'
 
 log = logging.getLogger(__name__)
 
@@ -49,9 +48,10 @@ def execute_openquake(
         #  oq engine --run /WORKING/examples/18_SWRG_INIT/4-sites_many-periods_vs30-475.ini
         # -L /WORKING/examples/18_SWRG_INIT/jobs/BG_unscaled.log
         #
-        cmd = ['oq', 'engine', '--run', f'{configfile}', '-L', f'{logfile}']
+        env = {**os.environ, 'OQ_DATADIR': str(OQ_DATADIR)}
+        cmd = [OQ_BIN, 'engine', '--run', f'{configfile}', '-L', f'{logfile}']
         log.info('cmd 1: %s', cmd)
-        subprocess.run(cmd)
+        subprocess.run(cmd, env=env)
 
         with open(logfile) as logf:
             oq_out = logf.read()
@@ -84,8 +84,8 @@ def execute_openquake(
                     6 |   complete | 2022-03-29 01:12:16 | 35 sites, few periods
                 """
 
-                cmd = ['oq', 'engine', '--lhc']
-                p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+                cmd = [OQ_BIN, 'engine', '--lhc']
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env)
                 out, err = p.communicate()
 
                 fileish = io.StringIO()
@@ -108,9 +108,9 @@ def execute_openquake(
             #  oq engine --export-outputs 12 /WORKING/examples/output/PROD/34-sites-few-CRU+BG
             #  cp /home/openquake/oqdata/calc_12.hdf5 /WORKING/examples/output/PROD
             #
-            cmd = ['oq', 'engine', '--export-outputs', str(last_task), str(output_path)]
+            cmd = [OQ_BIN, 'engine', '--export-outputs', str(last_task), str(output_path)]
             log.info('cmd 2: %s', cmd)
-            subprocess.check_call(cmd, stdout=subprocess.DEVNULL)
+            subprocess.check_call(cmd, stdout=subprocess.DEVNULL, env=env)
             oq_result['csv_archive'] = archive(
                 output_path, Path(WORK_PATH, f'openquake_csv_archive-{toshi_task_id}.zip')
             )
@@ -118,7 +118,7 @@ def execute_openquake(
             # clean up export outputs
             shutil.rmtree(output_path)
 
-            OQDATA = Path(get_datadir())
+            OQDATA = Path(str(OQ_DATADIR))
 
             hdf5_file = f"calc_{last_task}.hdf5"
             oq_result['hdf5_archive'] = archive(

--- a/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
+++ b/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
@@ -1,4 +1,6 @@
 import datetime as dt
+import json
+import subprocess
 import time
 import uuid
 import zipfile
@@ -6,18 +8,12 @@ from pathlib import Path
 
 from dateutil.tz import tzutc
 from nshm_toshi_client.task_relation import TaskRelation  # TODO deprecate
-
-try:
-    from openquake.converters.ucerf.parsers.sections_geojson import get_multi_fault_source
-    from openquake.hazardlib.sourcewriter import write_source_model
-except ImportError:
-    print("openquake not installed, not importing")
-
 from pydantic import BaseModel
 
+import runzi
 from runzi.arguments import SystemArgs, TaskLanguage
 from runzi.automation.file_utils import download_files, get_output_file_id
-from runzi.automation.local_config import API_KEY, API_URL, S3_URL, SPOOF, USE_API, WORK_PATH
+from runzi.automation.local_config import API_KEY, API_URL, OQ_VENV, S3_URL, SPOOF, USE_API, WORK_PATH
 from runzi.automation.toshi_api import ModelType, SubtaskType, ToshiApi
 from runzi.tasks.get_config import get_config
 
@@ -54,6 +50,9 @@ class OQConvertTask:
 
     def convert(self, src_folder: Path) -> Path:
 
+        if not OQ_VENV:
+            raise RuntimeError('NZSHM22_OQ_VENV must be set for OQ conversion tasks')
+
         # The `tectonic_region_type` label must be consistent with what you use in the
         # logic tree for the ground-motion characterisation
         # Use "Subduction Interface" or "Active Shallow Crust"
@@ -70,15 +69,24 @@ class OQConvertTask:
         investigation_time = self.user_args.investigation_time_years
         prefix = source_id
 
-        computed = get_multi_fault_source(
-            str(src_folder), dip_sd, strike_sd, source_id, source_name, tectonic_region_type, investigation_time, prefix
-        )
-
-        print(computed)
-
         out_file = WORK_PATH / f'{source_id}-ruptures.xml'
-        write_source_model(
-            str(out_file), [computed], name=source_name, investigation_time=investigation_time, prefix=prefix
+
+        oq_runner_script = Path(runzi.__file__).parent / '_oq_runner.py'
+        cfg_path = WORK_PATH / f'convert_cfg_{source_id}.json'
+        cfg_path.write_text(json.dumps({
+            'src_folder': str(src_folder),
+            'dip_sd': dip_sd,
+            'strike_sd': strike_sd,
+            'source_id': source_id,
+            'source_name': source_name,
+            'tectonic_region_type': tectonic_region_type,
+            'investigation_time': investigation_time,
+            'prefix': prefix,
+            'out_file': str(out_file),
+        }))
+        subprocess.run(
+            [f'{OQ_VENV}/bin/python', str(oq_runner_script), 'convert', '--config', str(cfg_path)],
+            check=True,
         )
 
         # zip this and return the archive path

--- a/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
+++ b/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
@@ -84,10 +84,13 @@ class OQConvertTask:
             'prefix': prefix,
             'out_file': str(out_file),
         }))
-        subprocess.run(
-            [f'{OQ_VENV}/bin/python', str(oq_runner_script), 'convert', '--config', str(cfg_path)],
-            check=True,
-        )
+        try:
+            subprocess.run(
+                [f'{OQ_VENV}/bin/python', str(oq_runner_script), 'convert', '--config', str(cfg_path)],
+                check=True,
+            )
+        finally:
+            cfg_path.unlink(missing_ok=True)
 
         # zip this and return the archive path
         # TODO: should we not archive the huge hdf5. I don't think it's needed, but this needs to be tested

--- a/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
+++ b/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
@@ -92,15 +92,17 @@ class OQConvertTask:
         finally:
             cfg_path.unlink(missing_ok=True)
 
-        # zip this and return the archive path
-        # TODO: should we not archive the huge hdf5. I don't think it's needed, but this needs to be tested
-        output_zip = Path(WORK_PATH, self.solution_archive_filename.replace('.zip', '_nrml.zip'))
+        # Zip the converted XML and return the archive path.
+        # Use source_id directly so the zip lands in WORK_PATH, not buried in the
+        # downloads subdirectory (solution_archive_filename is an absolute path, so
+        # Path(WORK_PATH, absolute) would discard WORK_PATH via Python path rules).
+        output_zip = WORK_PATH / f'{source_id}_nrml.zip'
         print(f'output: {output_zip}')
-        zfile = zipfile.ZipFile(output_zip, 'w')
-        for filename in list(WORK_PATH.glob(f'{source_id}*')):
-            arcname = str(filename).replace(str(WORK_PATH), '')
-            zfile.write(filename, arcname)
-            print(f'archived {filename} as {arcname}')
+        with zipfile.ZipFile(output_zip, 'w') as zfile:
+            for filename in list(WORK_PATH.glob(f'{source_id}*')):
+                arcname = str(filename).replace(str(WORK_PATH), '')
+                zfile.write(filename, arcname)
+                print(f'archived {filename} as {arcname}')
 
         return output_zip
 

--- a/tests/test_cli_cluster_mode.py
+++ b/tests/test_cli_cluster_mode.py
@@ -8,7 +8,6 @@ from typer.testing import CliRunner
 from runzi.automation import local_config
 from runzi.automation.local_config import ClusterModeEnum
 from runzi.cli import runzi_cli
-from runzi.cli.runzi_cli import cluster_mode_callback
 
 
 # some platforms print ANSI codes to the CLI output
@@ -24,30 +23,6 @@ runner = CliRunner(env=env)
 @pytest.fixture(autouse=True)
 def reset_cluster_mode():
     local_config.CLUSTER_MODE = ClusterModeEnum.LOCAL
-
-
-# ── Unit tests for the callback function itself ─────────────────────────────
-
-
-def test_callback_none_gets_default():
-    cluster_mode_callback()
-    assert local_config.CLUSTER_MODE is local_config.DEFAULT_CLUSTER_MODE
-
-
-def test_callback_sets_cluster_mode():
-    cluster_mode_callback(ClusterModeEnum.AWS)
-    assert local_config.CLUSTER_MODE is ClusterModeEnum.AWS
-
-
-def test_callback_sets_cluster_mode_cluster():
-    cluster_mode_callback(ClusterModeEnum.CLUSTER)
-    assert local_config.CLUSTER_MODE is ClusterModeEnum.CLUSTER
-
-
-def test_callback_default_when_none():
-    local_config.CLUSTER_MODE = ClusterModeEnum.CLUSTER  # non-default
-    cluster_mode_callback()
-    assert local_config.CLUSTER_MODE is local_config.DEFAULT_CLUSTER_MODE  # changed
 
 
 # ── Root CLI tests ───────────────────────────────────────────────────────────

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -1,6 +1,7 @@
 """Tests for the docker_wrapper module — TDD (RED phase first)."""
 
 import os
+import re
 
 import pytest
 from typer.testing import CliRunner
@@ -9,6 +10,13 @@ from runzi.cli import docker_wrapper
 from runzi.cli.runzi_cli import app
 
 runner = CliRunner(env={"NO_COLOR": "1", "LANG": "en_US.UTF-8"})
+
+_ANSI_RE = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences so plain-text assertions are CI-safe."""
+    return _ANSI_RE.sub('', text)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -402,7 +410,7 @@ def test_build_docker_cmd_image_at_end_before_args(aws_creds):
 
 def test_cli_help_shows_docker_flag():
     result = runner.invoke(app, ['--help'])
-    assert '--docker' in result.output
+    assert '--docker' in strip_ansi(result.output)
 
 
 def test_cli_docker_flag_invokes_wrapper(mocker, tmp_path):
@@ -670,8 +678,8 @@ def test_cli_docker_dry_run_uses_absolute_mount_for_relative_file(mocker, tmp_pa
     mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
     result = runner.invoke(app, ['--docker-dry-run', 'hazard', 'oq-hazard', 'foo.json'])
     assert result.exit_code == 0
-    assert str(tmp_path.resolve()) in result.output
-    assert '/INPUT_FILES/foo.json' in result.output
+    assert str(tmp_path.resolve()) in strip_ansi(result.output)
+    assert '/INPUT_FILES/foo.json' in strip_ansi(result.output)
 
 
 def test_cli_docker_forwards_subcommand_name_in_inner_args(mocker, tmp_path):

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -1,0 +1,436 @@
+"""Tests for the docker_wrapper module — TDD (RED phase first)."""
+
+import os
+
+import pytest
+from typer.testing import CliRunner
+
+from runzi.cli import docker_wrapper
+from runzi.cli.runzi_cli import app
+
+runner = CliRunner(env={"NO_COLOR": "1", "LANG": "en_US.UTF-8"})
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def has_flag(cmd: list[str], flag: str) -> bool:
+    return flag in cmd
+
+
+def has_volume(cmd: list[str], mount_spec: str) -> bool:
+    """Check that -v <mount_spec> appears as consecutive elements."""
+    for i, arg in enumerate(cmd):
+        if arg == '-v' and i + 1 < len(cmd) and cmd[i + 1] == mount_spec:
+            return True
+    return False
+
+
+def has_env(cmd: list[str], key: str, value: str | None = None) -> bool:
+    """Check that -e KEY or -e KEY=VALUE appears in cmd."""
+    for i, arg in enumerate(cmd):
+        if arg == '-e' and i + 1 < len(cmd):
+            entry = cmd[i + 1]
+            if value is None and entry.startswith(f'{key}'):
+                return True
+            if entry == f'{key}={value}':
+                return True
+    return False
+
+
+def flag_value(cmd: list[str], flag: str) -> str | None:
+    """Return the value after a flag, or None."""
+    try:
+        idx = cmd.index(flag)
+        return cmd[idx + 1]
+    except (ValueError, IndexError):
+        return None
+
+
+# ── find_file_args ────────────────────────────────────────────────────────────
+
+
+def test_find_file_args_returns_empty_for_no_args():
+    assert docker_wrapper.find_file_args([]) == []
+
+
+def test_find_file_args_ignores_non_path_strings():
+    assert docker_wrapper.find_file_args(['hazard', 'oq-hazard', '--help']) == []
+
+
+def test_find_file_args_detects_existing_file(tmp_path):
+    config = tmp_path / 'foo.json'
+    config.write_text('{}')
+    result = docker_wrapper.find_file_args(['hazard', 'oq-hazard', str(config)])
+    assert result == [config]
+
+
+def test_find_file_args_detects_multiple_files(tmp_path):
+    sub = tmp_path / 'sub'
+    sub.mkdir()
+    a = tmp_path / 'a.json'
+    b = sub / 'b.json'
+    a.write_text('{}')
+    b.write_text('{}')
+    result = docker_wrapper.find_file_args(['hazard', str(a), str(b)])
+    assert result == [a, b]
+
+
+def test_find_file_args_ignores_nonexistent_paths():
+    result = docker_wrapper.find_file_args(['/does/not/exist.json'])
+    assert result == []
+
+
+# ── common_ancestor ───────────────────────────────────────────────────────────
+
+
+def test_common_ancestor_single_file(tmp_path):
+    f = tmp_path / 'foo.json'
+    assert docker_wrapper.common_ancestor([f]) == tmp_path
+
+
+def test_common_ancestor_files_in_same_dir(tmp_path):
+    a = tmp_path / 'a.json'
+    b = tmp_path / 'b.json'
+    assert docker_wrapper.common_ancestor([a, b]) == tmp_path
+
+
+def test_common_ancestor_files_in_subdirs(tmp_path):
+    sub = tmp_path / 'sub'
+    a = tmp_path / 'a.json'
+    b = sub / 'b.json'
+    assert docker_wrapper.common_ancestor([a, b]) == tmp_path
+
+
+def test_common_ancestor_deep_subdirs(tmp_path):
+    d1 = tmp_path / 'configs' / 'hazard'
+    d2 = tmp_path / 'configs' / 'disagg'
+    a = d1 / 'a.json'
+    b = d2 / 'b.json'
+    assert docker_wrapper.common_ancestor([a, b]) == tmp_path / 'configs'
+
+
+# ── rewrite_file_args ─────────────────────────────────────────────────────────
+
+
+def test_rewrite_file_args_single_file_in_root(tmp_path):
+    f = tmp_path / 'foo.json'
+    args = ['hazard', 'oq-hazard', str(f)]
+    result = docker_wrapper.rewrite_file_args(args, [f], tmp_path)
+    assert result == ['hazard', 'oq-hazard', '/INPUT_FILES/foo.json']
+
+
+def test_rewrite_file_args_file_in_subdir(tmp_path):
+    sub = tmp_path / 'configs'
+    f = sub / 'foo.json'
+    args = ['hazard', 'oq-hazard', str(f)]
+    result = docker_wrapper.rewrite_file_args(args, [f], tmp_path)
+    assert result == ['hazard', 'oq-hazard', '/INPUT_FILES/configs/foo.json']
+
+
+def test_rewrite_file_args_multiple_files(tmp_path):
+    sub = tmp_path / 'sub'
+    a = tmp_path / 'a.json'
+    b = sub / 'b.json'
+    args = ['hazard', str(a), str(b)]
+    result = docker_wrapper.rewrite_file_args(args, [a, b], tmp_path)
+    assert result == ['hazard', '/INPUT_FILES/a.json', '/INPUT_FILES/sub/b.json']
+
+
+def test_rewrite_file_args_leaves_non_file_args_unchanged(tmp_path):
+    f = tmp_path / 'foo.json'
+    args = ['hazard', 'oq-hazard', '--some-flag', str(f)]
+    result = docker_wrapper.rewrite_file_args(args, [f], tmp_path)
+    assert result == ['hazard', 'oq-hazard', '--some-flag', '/INPUT_FILES/foo.json']
+
+
+# ── build_docker_cmd ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def aws_creds(tmp_path):
+    creds = tmp_path / 'credentials'
+    creds.write_text('[default]\naws_access_key_id = test')
+    return creds
+
+
+def test_build_docker_cmd_starts_with_docker_run(tmp_path, aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+    )
+    assert cmd[:2] == ['docker', 'run']
+
+
+def test_build_docker_cmd_has_rm_flag(tmp_path, aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+    )
+    assert '--rm' in cmd
+
+
+def test_build_docker_cmd_has_user_flag(aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+    )
+    expected_user = f'{os.getuid()}:{os.getgid()}'
+    assert flag_value(cmd, '--user') == expected_user
+
+
+def test_build_docker_cmd_mounts_aws_credentials(aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+    )
+    assert has_volume(cmd, f'{aws_creds}:/aws-credentials:ro')
+
+
+def test_build_docker_cmd_sets_aws_creds_env(aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+    )
+    assert has_env(cmd, 'AWS_SHARED_CREDENTIALS_FILE', '/aws-credentials')
+
+
+def test_build_docker_cmd_shell_uses_bash_entrypoint(aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+    )
+    assert flag_value(cmd, '--entrypoint') == 'bash'
+
+
+def test_build_docker_cmd_passthrough_uses_runzi_entrypoint(tmp_path, aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=['hazard', 'oq-hazard', '/INPUT_FILES/foo.json'],
+        image='runzi-build:latest',
+        dev=False,
+        shell=False,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+        input_dir=tmp_path,
+    )
+    assert flag_value(cmd, '--entrypoint') == 'runzi'
+
+
+def test_build_docker_cmd_passthrough_appends_runzi_args(tmp_path, aws_creds):
+    inner = ['hazard', 'oq-hazard', '/INPUT_FILES/foo.json']
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=inner,
+        image='runzi-build:latest',
+        dev=False,
+        shell=False,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+        input_dir=tmp_path,
+    )
+    # inner args appear at the end after the image
+    image_idx = cmd.index('runzi-build:latest')
+    assert cmd[image_idx + 1 :] == inner
+
+
+def test_build_docker_cmd_mounts_input_dir(tmp_path, aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+        input_dir=tmp_path,
+    )
+    assert has_volume(cmd, f'{tmp_path}:/INPUT_FILES:ro')
+
+
+def test_build_docker_cmd_no_input_dir_no_input_files_mount(aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+        input_dir=None,
+    )
+    assert '/INPUT_FILES' not in ' '.join(cmd)
+
+
+def test_build_docker_cmd_mounts_ths_dirs(tmp_path, aws_creds):
+    ths_h = tmp_path / 'hazard'
+    ths_d = tmp_path / 'disagg'
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=ths_h,
+        ths_disagg=ths_d,
+        env_vars={},
+    )
+    assert has_volume(cmd, f'{ths_h}:/THS/HAZARD')
+    assert has_volume(cmd, f'{ths_d}:/THS/DISAGG')
+
+
+def test_build_docker_cmd_skips_ths_mounts_when_none(aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+    )
+    assert '/THS/HAZARD' not in ' '.join(cmd)
+    assert '/THS/DISAGG' not in ' '.join(cmd)
+
+
+def test_build_docker_cmd_dev_mounts_runzi_source(tmp_path, aws_creds):
+    src = tmp_path / 'nzshm-runzi'
+    src.mkdir()
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:dev',
+        dev=True,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+        runzi_source=src,
+    )
+    assert has_volume(cmd, f'{src}:/app/nzshm-runzi')
+
+
+def test_build_docker_cmd_non_dev_does_not_mount_source(aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+        runzi_source=None,
+    )
+    assert '/app/nzshm-runzi' not in ' '.join(cmd)
+
+
+def test_build_docker_cmd_forwards_env_vars(aws_creds):
+    env = {'NZSHM22_TOSHI_API_URL': 'http://api', 'AWS_PROFILE': 'myprofile'}
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=[],
+        image='runzi-build:latest',
+        dev=False,
+        shell=True,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars=env,
+    )
+    assert has_env(cmd, 'NZSHM22_TOSHI_API_URL', 'http://api')
+    assert has_env(cmd, 'AWS_PROFILE', 'myprofile')
+
+
+def test_build_docker_cmd_image_at_end_before_args(aws_creds):
+    cmd = docker_wrapper.build_docker_cmd(
+        inner_args=['hazard', 'oq-hazard'],
+        image='runzi-build:latest',
+        dev=False,
+        shell=False,
+        aws_credentials=aws_creds,
+        ths_hazard=None,
+        ths_disagg=None,
+        env_vars={},
+    )
+    image_idx = cmd.index('runzi-build:latest')
+    assert cmd[image_idx + 1 :] == ['hazard', 'oq-hazard']
+
+
+# ── CLI integration ───────────────────────────────────────────────────────────
+
+
+def test_cli_help_shows_docker_flag():
+    result = runner.invoke(app, ['--help'])
+    assert '--docker' in result.output
+
+
+def test_cli_docker_flag_invokes_wrapper(mocker, tmp_path):
+    config = tmp_path / 'foo.json'
+    config.write_text('{}')
+    mock_run = mocker.patch('runzi.cli.docker_wrapper.run_in_docker', return_value=0)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', str(config)])
+    mock_run.assert_called_once()
+    assert result.exit_code == 0
+
+
+def test_cli_docker_dev_implies_docker(mocker, tmp_path):
+    config = tmp_path / 'foo.json'
+    config.write_text('{}')
+    mock_run = mocker.patch('runzi.cli.docker_wrapper.run_in_docker', return_value=0)
+    runner.invoke(app, ['--docker-dev', 'hazard', 'oq-hazard', str(config)])
+    mock_run.assert_called_once()
+    call_kwargs = mock_run.call_args
+    assert call_kwargs.kwargs.get('dev') is True or (call_kwargs.args and call_kwargs.args[1] is True)
+
+
+def test_cli_docker_shell_implies_docker(mocker):
+    mock_run = mocker.patch('runzi.cli.docker_wrapper.run_in_docker', return_value=0)
+    runner.invoke(app, ['--docker-shell'])
+    mock_run.assert_called_once()
+
+
+def test_cli_no_docker_flag_does_not_invoke_wrapper(mocker):
+    mock_run = mocker.patch('runzi.cli.docker_wrapper.run_in_docker', return_value=0)
+    runner.invoke(app, ['hazard', 'oq-hazard', '--help'])
+    mock_run.assert_not_called()

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -436,6 +436,158 @@ def test_cli_no_docker_flag_does_not_invoke_wrapper(mocker):
     mock_run.assert_not_called()
 
 
+def test_cli_docker_drops_host_script_work_path_env(mocker, tmp_path, monkeypatch):
+    """Host NZSHM22_SCRIPT_WORK_PATH must not be forwarded as an env var."""
+    (tmp_path / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    work = tmp_path / 'work'
+    monkeypatch.setenv('NZSHM22_SCRIPT_WORK_PATH', str(work))
+
+    captured: dict = {}
+
+    def fake_run(cmd, check=False):
+        captured['cmd'] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'foo.json'])
+    assert result.exit_code == 0
+    assert not has_env(captured['cmd'], 'NZSHM22_SCRIPT_WORK_PATH'), (
+        f'host NZSHM22_SCRIPT_WORK_PATH leaked into container: {captured["cmd"]}'
+    )
+
+
+def test_cli_docker_mounts_script_work_path(mocker, tmp_path, monkeypatch):
+    """Host NZSHM22_SCRIPT_WORK_PATH is mounted at /WORKING read-write."""
+    (tmp_path / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    work = tmp_path / 'work'
+    monkeypatch.setenv('NZSHM22_SCRIPT_WORK_PATH', str(work))
+
+    captured: dict = {}
+
+    def fake_run(cmd, check=False):
+        captured['cmd'] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'foo.json'])
+    assert result.exit_code == 0
+    assert has_volume(captured['cmd'], f'{work}:/WORKING'), (
+        f'work-path mount missing or wrong: {captured["cmd"]}'
+    )
+    assert work.is_dir()
+
+
+def test_cli_docker_no_work_path_mount_when_unset(mocker, tmp_path, monkeypatch):
+    """When host has no NZSHM22_SCRIPT_WORK_PATH, no /WORKING mount is added."""
+    (tmp_path / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv('NZSHM22_SCRIPT_WORK_PATH', raising=False)
+
+    captured: dict = {}
+
+    def fake_run(cmd, check=False):
+        captured['cmd'] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'foo.json'])
+    assert result.exit_code == 0
+    assert '/WORKING' not in ' '.join(captured['cmd'])
+
+
+def test_cli_docker_drops_image_path_env_vars(mocker, tmp_path, monkeypatch):
+    """Image-set path vars must not be forwarded to the container."""
+    (tmp_path / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('NZSHM22_OPENSHA_ROOT', '/host/opensha')
+    monkeypatch.setenv('NZSHM22_FATJAR', '/host/foo.jar')
+    monkeypatch.setenv('NZSHM22_OPENSHA_JRE', '/host/java')
+    monkeypatch.setenv('NZSHM22_OQ_VENV', '/host/oq-venv')
+    monkeypatch.setenv('NZSHM22_OQ_DATADIR', '/host/oqdata')
+
+    captured: dict = {}
+
+    def fake_run(cmd, check=False):
+        captured['cmd'] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'foo.json'])
+    assert result.exit_code == 0
+    for var in ('NZSHM22_OPENSHA_ROOT', 'NZSHM22_FATJAR', 'NZSHM22_OPENSHA_JRE', 'NZSHM22_OQ_VENV', 'NZSHM22_OQ_DATADIR'):
+        assert not has_env(captured['cmd'], var), f'{var} leaked into container'
+
+
+def test_cli_docker_forwards_allowlisted_nzshm_vars(mocker, tmp_path, monkeypatch):
+    """Non-path NZSHM22 vars on the allowlist are still forwarded."""
+    (tmp_path / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('NZSHM22_TOSHI_API_URL', 'http://api.example/graphql')
+    monkeypatch.setenv('NZSHM22_BUILD_PLOTS', 'TRUE')
+
+    captured: dict = {}
+
+    def fake_run(cmd, check=False):
+        captured['cmd'] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'foo.json'])
+    assert result.exit_code == 0
+    assert has_env(captured['cmd'], 'NZSHM22_TOSHI_API_URL', 'http://api.example/graphql')
+    assert has_env(captured['cmd'], 'NZSHM22_BUILD_PLOTS', 'TRUE')
+
+
+def test_cli_docker_ths_s3_value_still_forwarded(mocker, tmp_path, monkeypatch):
+    """THS s3:// value is forwarded via extra_env even though THS is not in the allowlist."""
+    (tmp_path / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('NZSHM22_THS_RLZ_DB', 's3://my-bucket/path')
+
+    captured: dict = {}
+
+    def fake_run(cmd, check=False):
+        captured['cmd'] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'foo.json'])
+    assert result.exit_code == 0
+    assert has_env(captured['cmd'], 'NZSHM22_THS_RLZ_DB', 's3://my-bucket/path')
+
+
 def test_cli_docker_sets_user_env_in_container(mocker, tmp_path, monkeypatch):
     """USER must be forwarded so getpass.getuser() doesn't fall back to pwd.getpwuid()."""
     (tmp_path / 'foo.json').write_text('{}')

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -190,6 +190,7 @@ def test_build_docker_cmd_has_rm_flag(tmp_path, aws_creds):
     assert '--rm' in cmd
 
 
+@pytest.mark.skipif(not hasattr(os, 'getuid'), reason='POSIX-only --user mapping')
 def test_build_docker_cmd_has_user_flag(aws_creds):
     cmd = docker_wrapper.build_docker_cmd(
         inner_args=[],

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -436,6 +436,90 @@ def test_cli_no_docker_flag_does_not_invoke_wrapper(mocker):
     mock_run.assert_not_called()
 
 
+def test_cli_docker_sets_user_env_in_container(mocker, tmp_path, monkeypatch):
+    """USER must be forwarded so getpass.getuser() doesn't fall back to pwd.getpwuid()."""
+    (tmp_path / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('USER', 'host-user')
+
+    captured: dict = {}
+
+    def fake_run(cmd, check=False):
+        captured['cmd'] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'foo.json'])
+    assert result.exit_code == 0
+    assert has_env(captured['cmd'], 'USER', 'host-user'), f'USER missing from cmd: {captured["cmd"]}'
+
+
+def test_cli_docker_sets_default_user_when_host_unset(mocker, tmp_path, monkeypatch):
+    """When host has no USER, a fallback value is still forwarded to the container."""
+    (tmp_path / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv('USER', raising=False)
+
+    captured: dict = {}
+
+    def fake_run(cmd, check=False):
+        captured['cmd'] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'foo.json'])
+    assert result.exit_code == 0
+    assert has_env(captured['cmd'], 'USER', 'runzi'), f'fallback USER missing: {captured["cmd"]}'
+
+
+def test_cli_docker_resolves_relative_path_to_absolute_mount(mocker, tmp_path, monkeypatch):
+    """Relative-path file args must produce an absolute -v mount source."""
+    sub = tmp_path / 'sub'
+    sub.mkdir()
+    (sub / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+
+    captured: dict = {}
+
+    def fake_run(cmd, check=False):
+        captured['cmd'] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
+    result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'sub/foo.json'])
+    assert result.exit_code == 0
+    cmd = captured['cmd']
+    expected_mount = f'{(tmp_path / "sub").resolve()}:/INPUT_FILES:ro'
+    assert expected_mount in cmd, f'expected absolute mount, got cmd: {cmd}'
+    assert '/INPUT_FILES/foo.json' in cmd
+
+
+def test_cli_docker_dry_run_uses_absolute_mount_for_relative_file(mocker, tmp_path, monkeypatch):
+    """--docker-dry-run output must reference the absolute path for a relative file arg."""
+    (tmp_path / 'foo.json').write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    mocker.patch('runzi.cli.docker_wrapper._maybe_pull')
+    result = runner.invoke(app, ['--docker-dry-run', 'hazard', 'oq-hazard', 'foo.json'])
+    assert result.exit_code == 0
+    assert str(tmp_path.resolve()) in result.output
+    assert '/INPUT_FILES/foo.json' in result.output
+
+
 def test_cli_docker_forwards_subcommand_name_in_inner_args(mocker, tmp_path):
     """Regression: --docker must include the subcommand name in inner_args.
 

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -536,7 +536,9 @@ def test_cli_docker_drops_image_path_env_vars(mocker, tmp_path, monkeypatch):
     mocker.patch('runzi.cli.docker_wrapper.subprocess.run', side_effect=fake_run)
     result = runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', 'foo.json'])
     assert result.exit_code == 0
-    for var in ('NZSHM22_OPENSHA_ROOT', 'NZSHM22_FATJAR', 'NZSHM22_OPENSHA_JRE', 'NZSHM22_OQ_VENV', 'NZSHM22_OQ_DATADIR'):
+    for var in (
+        'NZSHM22_OPENSHA_ROOT', 'NZSHM22_FATJAR', 'NZSHM22_OPENSHA_JRE', 'NZSHM22_OQ_VENV', 'NZSHM22_OQ_DATADIR'
+    ):
         assert not has_env(captured['cmd'], var), f'{var} leaked into container'
 
 

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -434,3 +434,20 @@ def test_cli_no_docker_flag_does_not_invoke_wrapper(mocker):
     mock_run = mocker.patch('runzi.cli.docker_wrapper.run_in_docker', return_value=0)
     runner.invoke(app, ['hazard', 'oq-hazard', '--help'])
     mock_run.assert_not_called()
+
+
+def test_cli_docker_forwards_subcommand_name_in_inner_args(mocker, tmp_path):
+    """Regression: --docker must include the subcommand name in inner_args.
+
+    ctx.protected_args holds the subcommand name; ctx.args holds the rest.
+    Passing only ctx.args drops the subcommand, so the container shows help.
+    """
+    config = tmp_path / 'foo.json'
+    config.write_text('{}')
+    mock_run = mocker.patch('runzi.cli.docker_wrapper.run_in_docker', return_value=0)
+    runner.invoke(app, ['--docker', 'hazard', 'oq-hazard', str(config)])
+    mock_run.assert_called_once()
+    inner_args = mock_run.call_args.args[0]
+    assert inner_args[0] == 'hazard', f'subcommand missing from inner_args: {inner_args}'
+    assert 'oq-hazard' in inner_args
+    assert str(config) in inner_args


### PR DESCRIPTION
This update solves 2 dev/ops challanges:
1. running runzi in docker was combersom due to the number of paths and env vars that had to be properly handled
2. installing openquake on top of runzi was delicate and often results in incorrect dependencies

- Streamlines running runzi in docker on local machine: previous workflow required passing multiple env vars and mounting volumes by hand. `--docker-*` tags in runzi CLI handle this with behind-the-scenes script
- Container runs as host UID to allow writing output to host machine.
- Docker build split into standard and dev builds. dev allows modifying code and re-running without re-building image
- OpenQuake python environment is isolated from runzi (for both openquake and converter tasks). This avoids collision of dependencies and improves flexibility with openquake versions and future runzi development
