### PR TITLE
Chore/304 batch config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+ - Consolidated AWS Batch compute config: tasks now inherit a single default Fargate job definition/queue instead of each hardcoding their own, and `get_ecs_job_config` validates memory/vcpu against the real Fargate size matrix (up to 16 vCPU) via `validate_fargate_resources`, replacing the inline assert table. See `docs/architecture/aws-batch-compute-consolidation.md`.
+
 ## [0.11.0] 2026-10-06
 
 ### Added

--- a/docs/architecture/aws-batch-compute-consolidation.md
+++ b/docs/architecture/aws-batch-compute-consolidation.md
@@ -1,0 +1,94 @@
+# AWS Batch compute: consolidate to a single Fargate environment
+
+## Decision
+
+**runzi targets a single AWS Batch Fargate compute environment, job definition, and job
+queue for every task.** The canonical names are the already-existing Fargate resources:
+
+- Job definition: `Fargate-runzi-opensha-JD`
+- Job queue: `BasicFargate_Q`
+
+These are the **defaults** on `SystemArgs` (`runzi/arguments.py`), so task modules no longer
+repeat them. A task only sets `ecs_memory` / `ecs_vcpu` / `ecs_max_job_time_min` (and may
+override the def/queue if a genuine need ever appears).
+
+The EC2 `BigLever_32GB_8VCPU_v2_JD` / `BigLever_32GB_8VCPU_v2_JQ` path — previously used only by
+the OpenQuake hazard and disaggregation tasks — is retired. Those tasks run on Fargate at
+8 vCPU / 32 GB.
+
+**Infrastructure-as-code is explicitly deferred.** The compute environment, job definition, and
+queue remain hand-created in the AWS console for now. This ADR and `docs/usage/aws_batch.md` are
+the interim source of truth and the spec a future IaC module should encode.
+
+## Two deciding inputs
+
+1. **Modern Fargate covers the whole workload.** AWS Fargate now supports up to 16 vCPU /
+   120 GB. The OQ tasks were the only reason a separate EC2 ("BigLever") environment existed —
+   at 8 vCPU / ~30 GB they fit comfortably inside Fargate's matrix. With that constraint gone,
+   there is no task that requires EC2, so a second compute environment is pure maintenance cost.
+2. **Everything is hand-managed and duplicated.** Twelve task modules each hard-coded a job
+   definition and queue name across two near-identical clusters, and `runzi/aws/aws.py` carried a
+   hand-written, duplicate-riddled vcpu/memory assert table. Collapsing to one default removes the
+   duplication; one compute environment is far less to maintain by hand until IaC arrives.
+
+## Background
+
+Before this change:
+
+| | OpenSHA / inversion / report tasks (10) | OQ hazard + disagg tasks (2) |
+|---|---|---|
+| Job definition | `Fargate-runzi-opensha-JD` | `BigLever_32GB_8VCPU_v2_JD` (EC2) |
+| Job queue | `BasicFargate_Q` | `BigLever_32GB_8VCPU_v2_JQ` (EC2) |
+| Sizing | 4 vCPU / 30720 MB | 8 vCPU / 30000 MB |
+
+`get_ecs_job_config()` sniffed `"Fargate" in job_definition` and, for Fargate, asserted the
+vcpu/memory pair against an inline table that only covered up to 4 vCPU and contained duplicate
+entries; EC2 jobs were never validated. A note: `ecs_memory=30000` (and `30720`) are **not valid
+at 8 vCPU on Fargate** — 8 vCPU memory must be a multiple of 4096 between 16384 and 61440 — so the
+OQ migration bumps memory to `32768` (32 GB), and the new validation enforces this for any task.
+
+## Consequences / deferred obligations
+
+Because IaC is deferred, the following are **manual, external obligations** rather than code:
+
+- **No source of truth for the live resources** beyond this ADR + `docs/usage/aws_batch.md`
+  until IaC is adopted.
+- **Before the OQ tasks are migrated to Fargate** (done in code separately), confirm in the
+  console that `Fargate-runzi-opensha-JD` has `platformCapabilities: ["FARGATE"]` and that the
+  compute environment behind `BasicFargate_Q` has `maxvCpus` high enough for the desired OQ
+  concurrency at 8 vCPU/job. No new resources are required — only capacity/config verification.
+- **After the OQ tasks are verified on Fargate**, delete the `BigLever_32GB_8VCPU_v2_*` compute
+  environment, job definition, and queue (and any other now-unused envs/defs/queues) so only the
+  single Fargate set remains.
+- **Static Fargate validation table can drift.** The vcpu/memory matrix is encoded statically in
+  `runzi/aws/aws.py`. This is an accepted low-severity trade-off:
+  - AWS only ever *expands* the Fargate matrix, so a stale table fails **closed** — it rejects a
+    newly-valid combo with a clear error rather than silently accepting an invalid one.
+  - `submit_job` is the real validator; the local table is a fast, friendly pre-check, not the
+    source of truth.
+  - Refresh is cheap: the matrix is a single module-level constant with a doc-comment linking the
+    AWS "Fargate task CPU and memory" reference and a `# last verified: YYYY-MM` marker, so a
+    future update is a one-line edit.
+
+## Followups not blocking this decision
+
+- **Adopt infrastructure-as-code** (Terraform or AWS CDK) to encode the single compute
+  environment, job definition, and queue, replacing the console-managed resources. This ADR plus
+  `docs/usage/aws_batch.md` are the spec.
+- **Optional dynamic resource validation** — query the Batch/ECS API for the compute
+  environment's real capabilities instead of the static matrix. Needs live AWS credentials and is
+  heavier; only worth it if the static table proves to drift painfully.
+- **Add an EC2 compute environment** only if a future task genuinely exceeds Fargate's limits
+  (>16 vCPU / 120 GB, GPU, or fast local scratch).
+
+## Files
+
+- `runzi/arguments.py` — `DEFAULT_JOB_DEFINITION` / `DEFAULT_JOB_QUEUE` constants and the
+  `SystemArgs.ecs_job_definition` / `ecs_job_queue` field defaults.
+- `runzi/aws/aws.py` — `validate_fargate_resources()` and the Fargate vcpu/memory matrix constant
+  consumed by `get_ecs_job_config()`.
+- `runzi/tasks/*/*_task.py` — task modules now inherit the default def/queue; OQ tasks carry the
+  8 vCPU / 32 GB Fargate sizing.
+- `runzi/cli/build_and_deploy_container.py` — deploy default `job_definition` aligned to the
+  canonical Fargate name.
+- `docs/usage/aws_batch.md` — operator-facing description of the single Fargate architecture.

--- a/docs/architecture/aws-batch-compute-consolidation.md
+++ b/docs/architecture/aws-batch-compute-consolidation.md
@@ -78,15 +78,31 @@ Because IaC is deferred, the following are **manual, external obligations** rath
 - **Optional dynamic resource validation** — query the Batch/ECS API for the compute
   environment's real capabilities instead of the static matrix. Needs live AWS credentials and is
   heavier; only worth it if the static table proves to drift painfully.
-- **Add an EC2 compute environment** only if a future task genuinely exceeds Fargate's limits
-  (>16 vCPU / 120 GB, GPU, or fast local scratch).
+
+## Addendum: EC2 re-supported as a per-job opt-in
+
+The "add an EC2 compute environment only if a future task genuinely exceeds Fargate's limits"
+followup above has been actioned: `SystemArgs.ecs_compute_environment` (default `FARGATE`) lets
+a job opt into EC2 via its config file's `sys_arg_overrides`, supplying its own
+`ecs_job_definition` / `ecs_job_queue` (no canonical EC2 names — fully config-driven, unlike the
+Fargate defaults). `get_ecs_job_config()` branches its validation accordingly:
+`validate_fargate_resources()` for Fargate (unchanged), or a new `validate_ec2_resources()` for
+EC2 — a light positive-integer-vCPU / positive-memory check only, since EC2 sizing depends on
+the compute environment's instance types, which runzi can't know statically. See
+`docs/usage/aws_batch.md#targeting-ec2` for the operator-facing details and the `RUNNABLE`-forever
+failure mode this implies for oversized EC2 jobs.
+
+Fargate remains the default for every task; this does not reopen the EC2 BigLever path that was
+retired above — it's a new, narrower, per-job mechanism.
 
 ## Files
 
-- `runzi/arguments.py` — `DEFAULT_JOB_DEFINITION` / `DEFAULT_JOB_QUEUE` constants and the
-  `SystemArgs.ecs_job_definition` / `ecs_job_queue` field defaults.
-- `runzi/aws/aws.py` — `validate_fargate_resources()` and the Fargate vcpu/memory matrix constant
-  consumed by `get_ecs_job_config()`.
+- `runzi/arguments.py` — `DEFAULT_JOB_DEFINITION` / `DEFAULT_JOB_QUEUE` constants, the
+  `SystemArgs.ecs_job_definition` / `ecs_job_queue` field defaults, and the `ComputeEnvironment`
+  enum / `ecs_compute_environment` field (default `FARGATE`).
+- `runzi/aws/aws.py` — `validate_fargate_resources()` and the Fargate vcpu/memory matrix constant,
+  plus `validate_ec2_resources()`; both consumed by `get_ecs_job_config()`'s
+  `compute_environment`-keyed branch.
 - `runzi/tasks/*/*_task.py` — task modules now inherit the default def/queue; OQ tasks carry the
   8 vCPU / 32 GB Fargate sizing.
 - `runzi/cli/build_and_deploy_container.py` — deploy default `job_definition` aligned to the

--- a/docs/usage/aws_batch.md
+++ b/docs/usage/aws_batch.md
@@ -2,10 +2,12 @@ This describes the AWS Batch architecture `runzi` submits jobs to in `--cluster-
 the operator-facing companion to the decision recorded in
 [`docs/architecture/aws-batch-compute-consolidation.md`](../architecture/aws-batch-compute-consolidation.md).
 
-# Single Fargate architecture
+# Single Fargate architecture (default)
 
-Every task module submits to the same compute environment, job definition, and job queue. There
-is no EC2 compute environment.
+Every task module submits to the same compute environment, job definition, and job queue by
+default. EC2 is also available as an explicit per-job opt-in — see
+["Targeting EC2"](#targeting-ec2) below — but Fargate remains what every task gets unless a job
+asks otherwise.
 
 - **Compute environment**: Fargate, backing the queue below. `maxvCpus` must be high enough for
   the desired concurrency at up to 8 vCPU/job (the largest current task size, used by the OQ
@@ -26,6 +28,32 @@ names (`DEFAULT_JOB_DEFINITION` / `DEFAULT_JOB_QUEUE`), so task modules only nee
 `ecs_memory` / `ecs_vcpu` / `ecs_max_job_time_min`. `get_ecs_job_config()`
 (`runzi/aws/aws.py`) validates every `vcpu`/`memory` pair against AWS's published Fargate
 CPU/memory matrix before submission, and raises if a job won't fit.
+
+# Targeting EC2
+
+A job can opt into EC2 instead of Fargate by setting `ecs_compute_environment: ec2` in its
+config file's `sys_arg_overrides`, alongside an EC2 job definition and queue (there are no
+canonical EC2 names — runzi has no opinion on which EC2 compute environment you point at):
+
+```json
+"sys_arg_overrides": {
+  "ecs_compute_environment": "ec2",
+  "ecs_job_definition": "<your-ec2-job-definition>",
+  "ecs_job_queue": "<your-ec2-job-queue>"
+}
+```
+
+**Validation is light on purpose.** Unlike Fargate, EC2 has no fixed CPU/memory matrix —
+`resourceRequirements` are minimums that the Batch scheduler bin-packs onto whatever instance
+types your compute environment offers. `validate_ec2_resources()` (`runzi/aws/aws.py`) only
+checks that vCPU is a positive integer and memory is positive; it can't validate against real
+instance sizes because runzi doesn't know what's in your compute environment.
+
+**The failure mode to watch for:** if you request more memory than any instance in the compute
+environment can actually allocate, the job won't error at submission — it will sit in
+`RUNNABLE` forever with no clear message. An instance's *allocatable* memory is somewhat less
+than its advertised RAM (the OS, ECS agent, and Docker daemon reserve some), so size EC2 jobs
+with margin below your largest instance's total memory, not right up against it.
 
 # Updating the job definition
 

--- a/docs/usage/aws_batch.md
+++ b/docs/usage/aws_batch.md
@@ -1,0 +1,52 @@
+This describes the AWS Batch architecture `runzi` submits jobs to in `--cluster-mode AWS`. It is
+the operator-facing companion to the decision recorded in
+[`docs/architecture/aws-batch-compute-consolidation.md`](../architecture/aws-batch-compute-consolidation.md).
+
+# Single Fargate architecture
+
+Every task module submits to the same compute environment, job definition, and job queue. There
+is no EC2 compute environment.
+
+- **Compute environment**: Fargate, backing the queue below. `maxvCpus` must be high enough for
+  the desired concurrency at up to 8 vCPU/job (the largest current task size, used by the OQ
+  hazard/disagg tasks).
+- **Job definition**: `Fargate-runzi-opensha-JD`
+  - `platformCapabilities: ["FARGATE"]`
+  - Container image: the `nzshm22/runzi` image built and pushed by
+    `runzi utils docker-build` (`runzi/cli/build_and_deploy_container.py`)
+  - IAM role: the task execution/job role used to pull the image and run the container
+  - Job-definition-owned env vars (not forwarded by runzi; see
+    [`environment_variables.md`](environment_variables.md#aws-batch-job-definition-env-vars)):
+    - `NZSHM22_TOSHI_M2M_SECRET_ARN`
+    - `NZSHM22_TOSHI_COGNITO_DOMAIN`
+- **Job queue**: `BasicFargate_Q`
+
+`SystemArgs.ecs_job_definition` / `ecs_job_queue` (`runzi/arguments.py`) default to these two
+names (`DEFAULT_JOB_DEFINITION` / `DEFAULT_JOB_QUEUE`), so task modules only need to set
+`ecs_memory` / `ecs_vcpu` / `ecs_max_job_time_min`. `get_ecs_job_config()`
+(`runzi/aws/aws.py`) validates every `vcpu`/`memory` pair against AWS's published Fargate
+CPU/memory matrix before submission, and raises if a job won't fit.
+
+# Updating the job definition
+
+`runzi utils docker-build` builds the image, pushes it to ECR, and re-registers
+`Fargate-runzi-opensha-JD` with the new image (`update_job_definition()` in
+`runzi/cli/build_and_deploy_container.py`). It carries forward the existing definition's
+`platformCapabilities`, `parameters`, and `containerProperties` (with the image swapped) — AWS
+defaults `platformCapabilities` to `EC2` when omitted, which would silently break Fargate's
+fractional vCPU values, so this must always be forwarded explicitly.
+
+# Future: infrastructure-as-code
+
+The compute environment, job definition, and job queue above are currently created and managed
+by hand in the AWS console — there is no Terraform/CDK/CloudFormation for them. This doc and the
+ADR are the interim source of truth.
+
+When IaC is adopted, it should encode:
+- The Fargate compute environment (`maxvCpus`, subnets, security groups)
+- The `Fargate-runzi-opensha-JD` job definition (image reference, IAM role, `platformCapabilities`,
+  the M2M env vars above)
+- The `BasicFargate_Q` job queue
+
+Until then, any change to these resources must be made manually in the console and reflected back
+into this doc.

--- a/runzi/arguments.py
+++ b/runzi/arguments.py
@@ -15,6 +15,18 @@ class TaskLanguage(Enum):
     JAVA = 'java'
 
 
+class ComputeEnvironment(Enum):
+    """Which AWS Batch compute target a job runs on.
+
+    Fargate is the default for every task; EC2 is an explicit per-job opt-in (set via a config
+    file's sys_arg_overrides) for jobs that need a size or instance feature Fargate can't
+    provide. See docs/usage/aws_batch.md.
+    """
+
+    FARGATE = 'fargate'
+    EC2 = 'ec2'
+
+
 # Canonical AWS Batch compute target. All tasks share a single Fargate compute environment,
 # job definition, and queue (see docs/architecture/aws-batch-compute-consolidation.md).
 DEFAULT_JOB_DEFINITION = "Fargate-runzi-opensha-JD"
@@ -36,6 +48,7 @@ class SystemArgs(BaseModel):
     ecs_vcpu: int
     ecs_job_definition: str = DEFAULT_JOB_DEFINITION
     ecs_job_queue: str = DEFAULT_JOB_QUEUE
+    ecs_compute_environment: ComputeEnvironment = ComputeEnvironment.FARGATE
     ecs_extra_env: list[BatchEnvironmentSetting] | None = None
 
 

--- a/runzi/arguments.py
+++ b/runzi/arguments.py
@@ -15,6 +15,12 @@ class TaskLanguage(Enum):
     JAVA = 'java'
 
 
+# Canonical AWS Batch compute target. All tasks share a single Fargate compute environment,
+# job definition, and queue (see docs/architecture/aws-batch-compute-consolidation.md).
+DEFAULT_JOB_DEFINITION = "Fargate-runzi-opensha-JD"
+DEFAULT_JOB_QUEUE = "BasicFargate_Q"
+
+
 class SystemArgs(BaseModel):
     task_language: TaskLanguage
     general_task_id: str | None = None
@@ -28,8 +34,8 @@ class SystemArgs(BaseModel):
     ecs_max_job_time_min: int
     ecs_memory: int
     ecs_vcpu: int
-    ecs_job_definition: str
-    ecs_job_queue: str
+    ecs_job_definition: str = DEFAULT_JOB_DEFINITION
+    ecs_job_queue: str = DEFAULT_JOB_QUEUE
     ecs_extra_env: list[BatchEnvironmentSetting] | None = None
 
 

--- a/runzi/aws/aws.py
+++ b/runzi/aws/aws.py
@@ -163,11 +163,7 @@ def get_ecs_job_config(
     ths_disagg_rlz_db = ths_disagg_rlz_db or '/WORKING/THS_DISAGG_RLZ'
     ecr_digest = ecr_digest or "sha256:NOT_SET"
     task_config = get_task_config(task_args, task_system_args, model_type)
-    # Interim: only Fargate job definitions are validated against the Fargate size matrix. The EC2
-    # BigLever path (OQ tasks) skips this until those tasks migrate to Fargate, after which this
-    # guard is removed and every job is Fargate-validated.
-    if "Fargate" in job_definition:
-        validate_fargate_resources(vcpu, memory)
+    validate_fargate_resources(vcpu, memory)
 
     config: dict[str, Any] = {
         "jobName": job_name,

--- a/runzi/aws/aws.py
+++ b/runzi/aws/aws.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 
 BatchEnvironmentSetting = collections.namedtuple('BatchEnvironmentSetting', 'name value')
 
+# AWS Batch SubmitJob hard limit on the total size of containerOverrides.
+MAX_CONTAINER_OVERRIDES_BYTES = 8192
+
 
 def _fargate_memory_values(min_mb: int, max_mb: int, step_mb: int) -> tuple[int, ...]:
     return tuple(range(min_mb, max_mb + 1, step_mb))
@@ -202,5 +205,13 @@ def get_ecs_job_config(
     if extra_env:
         for ex in extra_env:
             config['containerOverrides']['environment'].append(dict(name=ex.name, value=ex.value))
+
+    overrides_size = len(json.dumps(config['containerOverrides']))
+    if overrides_size > MAX_CONTAINER_OVERRIDES_BYTES:
+        raise ValueError(
+            f"containerOverrides is {overrides_size} bytes, which exceeds AWS Batch's "
+            f"{MAX_CONTAINER_OVERRIDES_BYTES}-byte limit even after compression. The task config is too "
+            "large to ship inline; it needs to be staged externally (e.g. S3) and referenced instead."
+        )
 
     return config

--- a/runzi/aws/aws.py
+++ b/runzi/aws/aws.py
@@ -25,6 +25,51 @@ if TYPE_CHECKING:
 BatchEnvironmentSetting = collections.namedtuple('BatchEnvironmentSetting', 'name value')
 
 
+def _fargate_memory_values(min_mb: int, max_mb: int, step_mb: int) -> tuple[int, ...]:
+    return tuple(range(min_mb, max_mb + 1, step_mb))
+
+
+# Valid AWS Fargate task vCPU/memory(MB) combinations, encoded from the AWS docs table
+# "Fargate task CPU and memory":
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-defs.html#fargate-tasks-size
+# AWS only ever expands this matrix, so a stale copy fails closed (rejects a newly-valid combo)
+# rather than accepting an invalid one; submit_job is the ultimate validator. To refresh, update
+# the ranges below and bump the marker.
+# last verified: 2026-06
+FARGATE_VCPU_MEMORY_MB: dict[float, tuple[int, ...]] = {
+    0.25: (512, 1024, 2048),
+    0.5: _fargate_memory_values(1024, 4096, 1024),
+    1: _fargate_memory_values(2048, 8192, 1024),
+    2: _fargate_memory_values(4096, 16384, 1024),
+    4: _fargate_memory_values(8192, 30720, 1024),
+    8: _fargate_memory_values(16384, 61440, 4096),
+    16: _fargate_memory_values(32768, 122880, 8192),
+}
+
+
+def validate_fargate_resources(vcpu: float, memory: int) -> None:
+    """Validate a vCPU/memory pair against the AWS Fargate task size matrix.
+
+    Args:
+        vcpu: requested vCPU (must be a Fargate-supported value).
+        memory: requested memory in MB.
+
+    Raises:
+        ValueError: if vcpu is not a supported Fargate value, or memory is not a valid
+            amount for that vcpu.
+    """
+    if vcpu not in FARGATE_VCPU_MEMORY_MB:
+        raise ValueError(
+            f"vcpu={vcpu} is not a valid Fargate vCPU value; choose one of {sorted(FARGATE_VCPU_MEMORY_MB)}"
+        )
+    valid_memory = FARGATE_VCPU_MEMORY_MB[vcpu]
+    if memory not in valid_memory:
+        raise ValueError(
+            f"memory={memory} MB is not valid for {vcpu} vCPU on Fargate; valid values are "
+            f"{valid_memory[0]}-{valid_memory[-1]} MB (allowed: {list(valid_memory)})"
+        )
+
+
 def get_secret(secret_name, region_name):
 
     # Create a Secrets Manager client
@@ -115,63 +160,11 @@ def get_ecs_job_config(
     ths_disagg_rlz_db = ths_disagg_rlz_db or '/WORKING/THS_DISAGG_RLZ'
     ecr_digest = ecr_digest or "sha256:NOT_SET"
     task_config = get_task_config(task_args, task_system_args, model_type)
+    # Interim: only Fargate job definitions are validated against the Fargate size matrix. The EC2
+    # BigLever path (OQ tasks) skips this until those tasks migrate to Fargate, after which this
+    # guard is removed and every job is Fargate-validated.
     if "Fargate" in job_definition:
-        assert vcpu in [0.25, 0.5, 1, 2, 4]
-        assert memory in [
-            512,
-            1024,
-            2048,  # value = 0.25
-            1024,
-            2048,
-            3072,
-            4096,  # value = 0.5
-            2048,
-            3072,
-            4096,
-            5120,
-            6144,
-            7168,
-            8192,  # value = 1
-            4096,
-            5120,
-            6144,
-            7168,
-            8192,
-            9216,
-            10240,
-            11264,
-            12288,
-            13312,
-            14336,
-            15360,
-            16384,  # value = 2
-            8192,
-            9216,
-            10240,
-            11264,
-            12288,
-            13312,
-            14336,
-            15360,
-            16384,
-            17408,
-            18432,
-            19456,
-            20480,
-            21504,
-            22528,
-            23552,
-            24576,
-            25600,
-            26624,
-            27648,
-            28672,
-            29696,
-            30720,  # value = 4
-        ]
-    #     job_queue = "BasicFargate_Q"
-    # else:
-    #     job_queue = "BigLeverOnDemandEC2-job-queue" #"getting-started-jun7" #"BiggerLeverQueue"
+        validate_fargate_resources(vcpu, memory)
 
     config: dict[str, Any] = {
         "jobName": job_name,

--- a/runzi/aws/aws.py
+++ b/runzi/aws/aws.py
@@ -20,7 +20,7 @@ from runzi.aws.session import get_session
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
-    from runzi.arguments import SystemArgs
+    from runzi.arguments import ComputeEnvironment, SystemArgs
 
 BatchEnvironmentSetting = collections.namedtuple('BatchEnvironmentSetting', 'name value')
 
@@ -72,6 +72,29 @@ def validate_fargate_resources(vcpu: float, memory: int) -> None:
             f"memory={memory} MB is not valid for {vcpu} vCPU on Fargate; valid values are "
             f"{valid_memory[0]}-{valid_memory[-1]} MB (allowed: {list(valid_memory)})"
         )
+
+
+def validate_ec2_resources(vcpu: float, memory: int) -> None:
+    """Light sanity check for an EC2 vCPU/memory pair.
+
+    Unlike Fargate, EC2 has no fixed CPU/memory matrix: the values are minimums that the Batch
+    scheduler bin-packs onto whatever instance types the compute environment offers, so runzi
+    can't validate them against a static table. This only catches obviously-wrong values; the
+    scheduler is the real arbiter. A request that's too large for any instance in the compute
+    environment won't raise here — it will sit in RUNNABLE forever instead, so size EC2 jobs
+    with some margin below your largest instance's allocatable memory.
+
+    Args:
+        vcpu: requested vCPU; must be a positive integer.
+        memory: requested memory in MB; must be positive.
+
+    Raises:
+        ValueError: if vcpu is not a positive integer, or memory is not positive.
+    """
+    if vcpu < 1 or vcpu != int(vcpu):
+        raise ValueError(f"vcpu={vcpu} is not valid for EC2; must be a positive integer")
+    if memory <= 0:
+        raise ValueError(f"memory={memory} MB is not valid for EC2; must be positive")
 
 
 def get_secret(secret_name, region_name):
@@ -158,13 +181,20 @@ def get_ecs_job_config(
     job_queue: str,
     extra_env: list[BatchEnvironmentSetting] | None = None,
     use_compression=False,
+    compute_environment: 'ComputeEnvironment | str' = 'fargate',
 ):
 
     ths_rlz_db = ths_rlz_db or '/WORKING/THS_RLZ'
     ths_disagg_rlz_db = ths_disagg_rlz_db or '/WORKING/THS_DISAGG_RLZ'
     ecr_digest = ecr_digest or "sha256:NOT_SET"
     task_config = get_task_config(task_args, task_system_args, model_type)
-    validate_fargate_resources(vcpu, memory)
+    # compute_environment may be the ComputeEnvironment enum or a raw string (sys_arg_overrides
+    # applies config-file overrides via setattr, which bypasses pydantic coercion).
+    compute_target = getattr(compute_environment, 'value', compute_environment)
+    if compute_target == 'ec2':
+        validate_ec2_resources(vcpu, memory)
+    else:
+        validate_fargate_resources(vcpu, memory)
 
     config: dict[str, Any] = {
         "jobName": job_name,

--- a/runzi/aws/aws.py
+++ b/runzi/aws/aws.py
@@ -47,6 +47,7 @@ FARGATE_VCPU_MEMORY_MB: dict[float, tuple[int, ...]] = {
     4: _fargate_memory_values(8192, 30720, 1024),
     8: _fargate_memory_values(16384, 61440, 4096),
     16: _fargate_memory_values(32768, 122880, 8192),
+    32: (61440, 122880, 249856),  # 60 GB, 120 GB, 244 GB — discrete, not a stepped range
 }
 
 

--- a/runzi/build_tasks.py
+++ b/runzi/build_tasks.py
@@ -82,6 +82,7 @@ def build_tasks(
                 job_definition=system_args.ecs_job_definition,
                 job_queue=system_args.ecs_job_queue,
                 extra_env=system_args.ecs_extra_env,
+                use_compression=True,
             )
 
         else:

--- a/runzi/build_tasks.py
+++ b/runzi/build_tasks.py
@@ -83,6 +83,7 @@ def build_tasks(
                 job_queue=system_args.ecs_job_queue,
                 extra_env=system_args.ecs_extra_env,
                 use_compression=True,
+                compute_environment=system_args.ecs_compute_environment,
             )
 
         else:

--- a/runzi/cli/build_and_deploy_container.py
+++ b/runzi/cli/build_and_deploy_container.py
@@ -158,6 +158,7 @@ def update_job_definition(
     current_revision = current_def["revision"]
     current_arn = current_def["jobDefinitionArn"]
     current_parameters = current_def["parameters"]
+    current_platform_capabilities = current_def["platformCapabilities"]
 
     print(f"Current revision: {current_revision}")
     print(f"Current ARN: {current_arn}")
@@ -170,6 +171,7 @@ def update_job_definition(
         type="container",
         parameters=current_parameters,
         containerProperties=container_props,
+        platformCapabilities=current_platform_capabilities,
     )
 
     new_arn = response["jobDefinitionArn"]

--- a/runzi/cli/build_and_deploy_container.py
+++ b/runzi/cli/build_and_deploy_container.py
@@ -8,6 +8,8 @@ import typer
 from dotenv import load_dotenv
 from rich import print as rich_print
 
+from runzi.arguments import DEFAULT_JOB_DEFINITION
+
 load_dotenv()
 
 app = typer.Typer()
@@ -196,7 +198,7 @@ def build_and_deploy_container(
     region: str = typer.Option("us-east-1", envvar="AWS_REGION", help="AWS region"),
     aws_account_id: str = typer.Option("461564345538", envvar="AWS_ACCOUNT_ID", help="AWS account ID"),
     ecr_repo: str = typer.Option("nzshm22/runzi", envvar="ECR_REPO", help="ECR repository"),
-    job_definition: str = typer.Option("runzi_32GB_8VCPU_JD", envvar="JOB_DEFINITION", help="Batch job definition"),
+    job_definition: str = typer.Option(DEFAULT_JOB_DEFINITION, envvar="JOB_DEFINITION", help="Batch job definition"),
     dockerfile: str = typer.Option("docker/Dockerfile", envvar="DOCKERFILE", help="Path to Dockerfile"),
     skip_build: bool = typer.Option(default=False, help="Skip Docker build"),
     skip_push: bool = typer.Option(default=False, help="Skip ECR push"),

--- a/runzi/tasks/average_solutions/average_solutions_task.py
+++ b/runzi/tasks/average_solutions/average_solutions_task.py
@@ -22,8 +22,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=10,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
+++ b/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
@@ -54,8 +54,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=60,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/runzi/tasks/get_config.py
+++ b/runzi/tasks/get_config.py
@@ -3,6 +3,8 @@ import json
 import urllib.parse
 from typing import Any
 
+from runzi.aws import decompress_config
+
 
 def get_config() -> dict[str, Any]:
     """Get the job config from a JSON string or file.
@@ -18,8 +20,13 @@ def get_config() -> dict[str, Any]:
         # for AWS this must be a quoted JSON string
         config = json.loads(urllib.parse.unquote(args.config))
     except json.decoder.JSONDecodeError:
-        # LOCAL and CLUSTER this is a file
-        f = open(args.config, encoding='utf-8')
-        config = json.load(f)
+        try:
+            # for AWS this may instead be an LZMA+base64 compressed JSON string
+            # (used when the quoted form would exceed Batch's containerOverrides limit)
+            config = json.loads(decompress_config(args.config))
+        except Exception:
+            # LOCAL and CLUSTER this is a file
+            f = open(args.config, encoding='utf-8')
+            config = json.load(f)
 
     return config

--- a/runzi/tasks/inversion/crustal_inversion_solution_task.py
+++ b/runzi/tasks/inversion/crustal_inversion_solution_task.py
@@ -29,8 +29,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=60,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/runzi/tasks/inversion/subduction_inversion_solution_task.py
+++ b/runzi/tasks/inversion/subduction_inversion_solution_task.py
@@ -24,8 +24,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=60,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/runzi/tasks/inversion_report/inversion_diags_report_task.py
+++ b/runzi/tasks/inversion_report/inversion_diags_report_task.py
@@ -22,8 +22,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=60,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/runzi/tasks/oq_hazard/oq_disagg_task.py
+++ b/runzi/tasks/oq_hazard/oq_disagg_task.py
@@ -59,10 +59,8 @@ default_system_args = SystemArgs(
     task_language=TaskLanguage.PYTHON,
     use_api=USE_API,
     ecs_max_job_time_min=30,
-    ecs_memory=30000,
+    ecs_memory=32768,
     ecs_vcpu=8,
-    ecs_job_definition="BigLever_32GB_8VCPU_v2_JD",
-    ecs_job_queue="BigLever_32GB_8VCPU_v2_JQ",
 )
 
 

--- a/runzi/tasks/oq_hazard/oq_hazard_task.py
+++ b/runzi/tasks/oq_hazard/oq_hazard_task.py
@@ -54,10 +54,8 @@ default_system_args = SystemArgs(
     task_language=TaskLanguage.PYTHON,
     use_api=USE_API,
     ecs_max_job_time_min=30,
-    ecs_memory=30000,
+    ecs_memory=32768,
     ecs_vcpu=8,
-    ecs_job_definition="BigLever_32GB_8VCPU_v2_JD",
-    ecs_job_queue="BigLever_32GB_8VCPU_v2_JQ",
 )
 
 

--- a/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
+++ b/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
@@ -23,8 +23,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=30,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/runzi/tasks/rupset_report/ruptset_diags_report_task.py
+++ b/runzi/tasks/rupset_report/ruptset_diags_report_task.py
@@ -21,8 +21,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=60,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/runzi/tasks/scale_solution/scale_solution_task.py
+++ b/runzi/tasks/scale_solution/scale_solution_task.py
@@ -23,8 +23,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=10,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
+++ b/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
@@ -34,8 +34,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=60,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/runzi/tasks/time_dependent_solution/time_dependent_solution_task.py
+++ b/runzi/tasks/time_dependent_solution/time_dependent_solution_task.py
@@ -36,8 +36,6 @@ default_system_args = SystemArgs(
     ecs_max_job_time_min=10,
     ecs_memory=30720,
     ecs_vcpu=4,
-    ecs_job_definition="Fargate-runzi-opensha-JD",
-    ecs_job_queue="BasicFargate_Q",
 )
 
 

--- a/tests/test_build_and_deploy_container.py
+++ b/tests/test_build_and_deploy_container.py
@@ -1,0 +1,42 @@
+"""Tests for runzi.cli.build_and_deploy_container.update_job_definition.
+
+register_job_definition defaults platformCapabilities to EC2 when it is omitted, and EC2
+rejects fractional vCPU values (e.g. 0.25) used by Fargate job definitions. update_job_definition
+must forward the existing job definition's platformCapabilities so re-registration keeps
+validating against Fargate.
+"""
+
+from runzi.cli.build_and_deploy_container import update_job_definition
+
+
+def _describe_job_definitions_response(platform_capabilities):
+    return {
+        "jobDefinitions": [
+            {
+                "revision": 3,
+                "jobDefinitionArn": "arn:aws:batch:us-east-1:123456789012:job-definition/Fargate-runzi-opensha-JD:3",
+                "parameters": {},
+                "containerProperties": {
+                    "image": "old-image",
+                    "resourceRequirements": [{"value": "0.25", "type": "VCPU"}],
+                },
+                "platformCapabilities": platform_capabilities,
+            }
+        ]
+    }
+
+
+def test_forwards_platform_capabilities_on_reregister(mocker):
+    """register_job_definition must be called with the source definition's platformCapabilities."""
+    mock_client = mocker.Mock()
+    mock_client.describe_job_definitions.return_value = _describe_job_definitions_response(["FARGATE"])
+    mock_client.register_job_definition.return_value = {
+        "jobDefinitionArn": "arn:aws:batch:us-east-1:123456789012:job-definition/Fargate-runzi-opensha-JD:4",
+        "revision": 4,
+    }
+    mocker.patch("boto3.client", return_value=mock_client)
+
+    update_job_definition("Fargate-runzi-opensha-JD", "new-image", "us-east-1")
+
+    _, kwargs = mock_client.register_job_definition.call_args
+    assert kwargs["platformCapabilities"] == ["FARGATE"]

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -1,0 +1,49 @@
+"""Tests for runzi.tasks.get_config.get_config.
+
+AWS Batch caps containerOverrides at 8192 bytes, so large task configs are shipped
+LZMA+base64 compressed (see runzi.aws.compress_config) instead of URL-quoted. get_config
+must be able to decode either form, plus the LOCAL/CLUSTER file-path form.
+"""
+
+import json
+
+import pytest
+
+from runzi.aws import compress_config
+from runzi.tasks.get_config import get_config
+
+
+def test_decodes_url_quoted_json(monkeypatch):
+    """The existing plain url-quoted JSON form still works."""
+    config = {"task_args": {"a": 1}, "task_system_args": {"b": 2}, "model_type": "X"}
+    quoted = __import__('urllib.parse', fromlist=['quote']).quote(json.dumps(config))
+    monkeypatch.setattr('sys.argv', ['prog', quoted])
+
+    assert get_config() == config
+
+
+def test_decodes_compressed_json(monkeypatch):
+    """A compressed (LZMA+base64) payload, as produced for AWS Fargate jobs, decodes back."""
+    config = {"task_args": {"a": 1}, "task_system_args": {"b": 2}, "model_type": "X"}
+    compressed = compress_config(json.dumps(config))
+    monkeypatch.setattr('sys.argv', ['prog', compressed])
+
+    assert get_config() == config
+
+
+def test_reads_from_file_when_not_json(monkeypatch, tmp_path):
+    """LOCAL/CLUSTER mode passes a path to a JSON file instead of an inline string."""
+    config = {"task_args": {"a": 1}, "task_system_args": {"b": 2}, "model_type": "X"}
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(config), encoding='utf-8')
+    monkeypatch.setattr('sys.argv', ['prog', str(config_file)])
+
+    assert get_config() == config
+
+
+def test_missing_file_raises(monkeypatch):
+    """A value that is neither quoted JSON, compressed JSON, nor an existing file should error."""
+    monkeypatch.setattr('sys.argv', ['prog', '/no/such/file/here.json'])
+
+    with pytest.raises(FileNotFoundError):
+        get_config()

--- a/tests/test_get_ecs_job_config.py
+++ b/tests/test_get_ecs_job_config.py
@@ -137,10 +137,18 @@ class TestValidateFargateResources:
             (8, 16384),
             (8, 32768),  # the value OQ tasks move to
             (16, 122880),
+            (32, 61440),  # 60 GB
+            (32, 122880),  # 120 GB
+            (32, 249856),  # 244 GB
         ],
     )
     def test_valid_combinations_pass(self, vcpu, memory):
         validate_fargate_resources(vcpu, memory)  # must not raise
+
+    def test_32_vcpu_rejects_non_discrete_memory(self):
+        """Unlike 8/16 vCPU, 32 vCPU only allows the three discrete values, not a stepped range."""
+        with pytest.raises(ValueError, match='not valid for 32 vCPU'):
+            validate_fargate_resources(32, 90112)  # 88 GB, between 60 and 120 but not allowed
 
     def test_invalid_vcpu_raises(self):
         with pytest.raises(ValueError, match='not a valid Fargate vCPU'):

--- a/tests/test_get_ecs_job_config.py
+++ b/tests/test_get_ecs_job_config.py
@@ -7,11 +7,12 @@ Scientist credentials are not accidentally overridden by M2M config.
 """
 
 import inspect
+import json
 
 import pytest
 
 from runzi.arguments import DEFAULT_JOB_DEFINITION, DEFAULT_JOB_QUEUE, SystemArgs, TaskLanguage
-from runzi.aws import get_ecs_job_config
+from runzi.aws import decompress_config, get_ecs_job_config
 from runzi.aws.aws import BatchEnvironmentSetting, validate_fargate_resources
 
 
@@ -169,6 +170,46 @@ class TestFargateValidationInJobConfig:
         mocker.patch('runzi.aws.aws.get_task_config', return_value={})
         result = _call_get_ecs_job_config(vcpu=8, memory=30000)  # BasicEC2 default name
         assert result['jobDefinition'] == 'BasicEC2-job-definition'
+
+
+class TestCompression:
+    """Large task configs are shipped LZMA+base64 compressed to stay under Batch's
+    containerOverrides limit; AWS Batch caps containerOverrides at 8192 bytes."""
+
+    def test_use_compression_round_trips(self, mocker):
+        """With use_compression=True, TASK_CONFIG_JSON_QUOTED decodes back via decompress_config."""
+        task_config = {"task_args": {"a": 1}, "task_system_args": {"b": 2}, "model_type": "X"}
+        mocker.patch('runzi.aws.aws.get_task_config', return_value=task_config)
+
+        result = _call_get_ecs_job_config(use_compression=True)
+        env = {e['name']: e['value'] for e in result['containerOverrides']['environment']}
+        decoded = json.loads(decompress_config(env['TASK_CONFIG_JSON_QUOTED']))
+        assert decoded == task_config
+
+    def test_use_compression_shrinks_large_config(self, mocker):
+        """Compression should produce a smaller payload than url-quoting for a repetitive config."""
+        large_task_config = {"items": [{"name": f"item-{i}", "value": "x" * 20} for i in range(50)]}
+        mocker.patch('runzi.aws.aws.get_task_config', return_value=large_task_config)
+
+        quoted_result = _call_get_ecs_job_config(use_compression=False)
+        compressed_result = _call_get_ecs_job_config(use_compression=True)
+
+        quoted_env = {e['name']: e['value'] for e in quoted_result['containerOverrides']['environment']}
+        compressed_env = {e['name']: e['value'] for e in compressed_result['containerOverrides']['environment']}
+        assert len(compressed_env['TASK_CONFIG_JSON_QUOTED']) < len(quoted_env['TASK_CONFIG_JSON_QUOTED'])
+
+    def test_oversized_container_overrides_rejected(self, mocker):
+        """get_ecs_job_config fails fast if containerOverrides would exceed Batch's 8192-byte limit,
+        instead of letting submit_job fail with a cryptic AWS error."""
+        # Not compressible (random-looking) and large enough that even compression can't save it.
+        import random
+        import string
+
+        huge_task_config = {"blob": ''.join(random.choices(string.ascii_letters + string.digits, k=20000))}
+        mocker.patch('runzi.aws.aws.get_task_config', return_value=huge_task_config)
+
+        with pytest.raises(ValueError, match='8192'):
+            _call_get_ecs_job_config(use_compression=True)
 
 
 class TestSystemArgsComputeDefaults:

--- a/tests/test_get_ecs_job_config.py
+++ b/tests/test_get_ecs_job_config.py
@@ -11,9 +11,9 @@ import json
 
 import pytest
 
-from runzi.arguments import DEFAULT_JOB_DEFINITION, DEFAULT_JOB_QUEUE, SystemArgs, TaskLanguage
+from runzi.arguments import DEFAULT_JOB_DEFINITION, DEFAULT_JOB_QUEUE, ComputeEnvironment, SystemArgs, TaskLanguage
 from runzi.aws import decompress_config, get_ecs_job_config
-from runzi.aws.aws import BatchEnvironmentSetting, validate_fargate_resources
+from runzi.aws.aws import BatchEnvironmentSetting, validate_ec2_resources, validate_fargate_resources
 
 
 def _call_get_ecs_job_config(**overrides):
@@ -161,8 +161,8 @@ class TestValidateFargateResources:
 
 
 class TestFargateValidationInJobConfig:
-    """get_ecs_job_config always validates vcpu/memory against the Fargate matrix, since every
-    job now targets the single Fargate queue (no EC2 job definitions remain)."""
+    """get_ecs_job_config validates vcpu/memory against the Fargate matrix by default
+    (compute_environment defaults to FARGATE)."""
 
     def test_invalid_fargate_size_rejected(self, mocker):
         mocker.patch('runzi.aws.aws.get_task_config', return_value={})
@@ -179,6 +179,49 @@ class TestFargateValidationInJobConfig:
         mocker.patch('runzi.aws.aws.get_task_config', return_value={})
         with pytest.raises(ValueError):
             _call_get_ecs_job_config(vcpu=8, memory=30000)  # BasicEC2-job-definition default name
+
+
+class TestValidateEc2Resources:
+    """validate_ec2_resources only does a light sanity check: EC2 sizing depends on the
+    compute environment's instance types, which runzi can't know statically."""
+
+    def test_normal_combination_passes(self):
+        validate_ec2_resources(8, 30000)  # must not raise; not a valid Fargate size, fine on EC2
+
+    def test_non_positive_memory_raises(self):
+        with pytest.raises(ValueError, match='memory'):
+            validate_ec2_resources(2, 0)
+
+    def test_vcpu_below_one_raises(self):
+        with pytest.raises(ValueError, match='vcpu'):
+            validate_ec2_resources(0, 4096)
+
+
+class TestComputeEnvironmentInJobConfig:
+    """get_ecs_job_config branches its validation on compute_environment."""
+
+    def test_ec2_accepts_off_fargate_matrix_size(self, mocker):
+        """8 vCPU / 30000 MB is invalid for Fargate but fine for EC2 (light check only)."""
+        mocker.patch('runzi.aws.aws.get_task_config', return_value={})
+        result = _call_get_ecs_job_config(
+            compute_environment=ComputeEnvironment.EC2, vcpu=8, memory=30000
+        )
+        assert result['containerOverrides']['resourceRequirements'] == [
+            {"value": "30000", "type": "MEMORY"},
+            {"value": "8", "type": "VCPU"},
+        ]
+
+    def test_fargate_still_rejects_off_matrix_size(self, mocker):
+        """Same size is still rejected when compute_environment is FARGATE (the default)."""
+        mocker.patch('runzi.aws.aws.get_task_config', return_value={})
+        with pytest.raises(ValueError):
+            _call_get_ecs_job_config(compute_environment=ComputeEnvironment.FARGATE, vcpu=8, memory=30000)
+
+    def test_string_compute_environment_is_coerced(self, mocker):
+        """sys_arg_overrides uses setattr, which can leave a raw string instead of the enum."""
+        mocker.patch('runzi.aws.aws.get_task_config', return_value={})
+        result = _call_get_ecs_job_config(compute_environment='ec2', vcpu=8, memory=30000)
+        assert result is not None
 
 
 class TestCompression:
@@ -234,3 +277,13 @@ class TestSystemArgsComputeDefaults:
         )
         assert args.ecs_job_definition == DEFAULT_JOB_DEFINITION
         assert args.ecs_job_queue == DEFAULT_JOB_QUEUE
+
+    def test_compute_environment_defaults_to_fargate(self):
+        args = SystemArgs(
+            task_language=TaskLanguage.PYTHON,
+            use_api=False,
+            ecs_max_job_time_min=10,
+            ecs_memory=2048,
+            ecs_vcpu=1,
+        )
+        assert args.ecs_compute_environment == ComputeEnvironment.FARGATE

--- a/tests/test_get_ecs_job_config.py
+++ b/tests/test_get_ecs_job_config.py
@@ -153,7 +153,8 @@ class TestValidateFargateResources:
 
 
 class TestFargateValidationInJobConfig:
-    """get_ecs_job_config validates only when the job definition targets Fargate."""
+    """get_ecs_job_config always validates vcpu/memory against the Fargate matrix, since every
+    job now targets the single Fargate queue (no EC2 job definitions remain)."""
 
     def test_invalid_fargate_size_rejected(self, mocker):
         mocker.patch('runzi.aws.aws.get_task_config', return_value={})
@@ -165,11 +166,11 @@ class TestFargateValidationInJobConfig:
         result = _call_get_ecs_job_config(job_definition=DEFAULT_JOB_DEFINITION, vcpu=8, memory=32768)
         assert result['jobDefinition'] == DEFAULT_JOB_DEFINITION
 
-    def test_non_fargate_job_definition_skips_validation(self, mocker):
-        """An EC2 job definition skips the Fargate matrix check (interim BigLever path)."""
+    def test_invalid_size_rejected_regardless_of_job_definition_name(self, mocker):
+        """Validation no longer keys off the job definition name; any job definition is checked."""
         mocker.patch('runzi.aws.aws.get_task_config', return_value={})
-        result = _call_get_ecs_job_config(vcpu=8, memory=30000)  # BasicEC2 default name
-        assert result['jobDefinition'] == 'BasicEC2-job-definition'
+        with pytest.raises(ValueError):
+            _call_get_ecs_job_config(vcpu=8, memory=30000)  # BasicEC2-job-definition default name
 
 
 class TestCompression:

--- a/tests/test_get_ecs_job_config.py
+++ b/tests/test_get_ecs_job_config.py
@@ -8,8 +8,11 @@ Scientist credentials are not accidentally overridden by M2M config.
 
 import inspect
 
+import pytest
+
+from runzi.arguments import DEFAULT_JOB_DEFINITION, DEFAULT_JOB_QUEUE, SystemArgs, TaskLanguage
 from runzi.aws import get_ecs_job_config
-from runzi.aws.aws import BatchEnvironmentSetting
+from runzi.aws.aws import BatchEnvironmentSetting, validate_fargate_resources
 
 
 def _call_get_ecs_job_config(**overrides):
@@ -117,3 +120,67 @@ class TestContainerEnvContents:
         result = _call_get_ecs_job_config(ths_disagg_rlz_db=None)
         env = {e['name']: e['value'] for e in result['containerOverrides']['environment']}
         assert env['NZSHM22_THS_DISAGG_RLZ_DB'] == '/WORKING/THS_DISAGG_RLZ'
+
+
+class TestValidateFargateResources:
+    """validate_fargate_resources enforces the AWS Fargate vCPU/memory matrix."""
+
+    @pytest.mark.parametrize(
+        'vcpu, memory',
+        [
+            (0.25, 512),
+            (0.5, 4096),
+            (1, 2048),
+            (2, 16384),
+            (4, 30720),
+            (8, 16384),
+            (8, 32768),  # the value OQ tasks move to
+            (16, 122880),
+        ],
+    )
+    def test_valid_combinations_pass(self, vcpu, memory):
+        validate_fargate_resources(vcpu, memory)  # must not raise
+
+    def test_invalid_vcpu_raises(self):
+        with pytest.raises(ValueError, match='not a valid Fargate vCPU'):
+            validate_fargate_resources(6, 16384)
+
+    def test_invalid_memory_for_vcpu_raises(self):
+        # 30000 is not a valid 8-vCPU Fargate memory (must be a multiple of 4096 in 16384..61440).
+        with pytest.raises(ValueError, match='not valid for 8 vCPU'):
+            validate_fargate_resources(8, 30000)
+
+
+class TestFargateValidationInJobConfig:
+    """get_ecs_job_config validates only when the job definition targets Fargate."""
+
+    def test_invalid_fargate_size_rejected(self, mocker):
+        mocker.patch('runzi.aws.aws.get_task_config', return_value={})
+        with pytest.raises(ValueError):
+            _call_get_ecs_job_config(job_definition=DEFAULT_JOB_DEFINITION, vcpu=8, memory=30000)
+
+    def test_valid_fargate_size_accepted(self, mocker):
+        mocker.patch('runzi.aws.aws.get_task_config', return_value={})
+        result = _call_get_ecs_job_config(job_definition=DEFAULT_JOB_DEFINITION, vcpu=8, memory=32768)
+        assert result['jobDefinition'] == DEFAULT_JOB_DEFINITION
+
+    def test_non_fargate_job_definition_skips_validation(self, mocker):
+        """An EC2 job definition skips the Fargate matrix check (interim BigLever path)."""
+        mocker.patch('runzi.aws.aws.get_task_config', return_value={})
+        result = _call_get_ecs_job_config(vcpu=8, memory=30000)  # BasicEC2 default name
+        assert result['jobDefinition'] == 'BasicEC2-job-definition'
+
+
+class TestSystemArgsComputeDefaults:
+    """SystemArgs supplies the single canonical Fargate def/queue by default."""
+
+    def test_job_def_and_queue_default_to_fargate(self):
+        args = SystemArgs(
+            task_language=TaskLanguage.PYTHON,
+            use_api=False,
+            ecs_max_job_time_min=10,
+            ecs_memory=2048,
+            ecs_vcpu=1,
+        )
+        assert args.ecs_job_definition == DEFAULT_JOB_DEFINITION
+        assert args.ecs_job_queue == DEFAULT_JOB_QUEUE


### PR DESCRIPTION
closes #304 

# Summary
  - All task modules now inherit one default Fargate job definition/queue instead of hardcoding their own; get_ecs_job_config validates vcpu/memory against the real Fargate size matrix (now
  up to 32 vCPU) via validate_fargate_resources, replacing ad-hoc inline asserts.
  - Jobs can opt out of the shared Fargate queue into EC2 via ecs_compute_environment: ec2 in sys_arg_overrides, supplying their own job definition/queue; validation there is intentionally
  light (validate_ec2_resources) since EC2 sizing isn't statically known.
  - Fixed two Batch submission bugs: task configs are now compressed to stay under the containerOverrides 8192-byte limit (with fail-fast on oversized configs), and docker-build's job
  definition re-registration now forwards platformCapabilities to avoid a cryptic Fargate fractional-vCPU error.
  - Documented the architecture and EC2 opt-in in docs/architecture/aws-batch-compute-consolidation.md and docs/usage/aws_batch.md.

# Test plan
  - [x] pytest --cov=runzi --cov-branch tests runzi
  - [x] ruff check runzi tests && mypy runzi tests