### PR TITLE
AWS Batch compute IaC (Phase 1): Terraform for the Fargate env + queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Changed
- - Consolidated AWS Batch compute config: tasks now inherit a single default Fargate job definition/queue instead of each hardcoding their own, and `get_ecs_job_config` validates memory/vcpu against the real Fargate size matrix (up to 16 vCPU) via `validate_fargate_resources`, replacing the inline assert table. See `docs/architecture/aws-batch-compute-consolidation.md`.
+ - Consolidated AWS Batch compute config: tasks now inherit a single default Fargate job definition/queue instead of each hardcoding their own, and `get_ecs_job_config` validates memory/vcpu against the real Fargate size matrix (up to 16 vCPU) via `validate_fargate_resources`, replacing the inline assert table. See `docs/architecture/adr/0003-aws-batch-compute-consolidation.md`.
 
 ## [0.11.0] 2026-10-06
 

--- a/docs/architecture/adr/0003-aws-batch-compute-consolidation.md
+++ b/docs/architecture/adr/0003-aws-batch-compute-consolidation.md
@@ -75,6 +75,11 @@ Because IaC is deferred, the following are **manual, external obligations** rath
 - **Adopt infrastructure-as-code** (Terraform or AWS CDK) to encode the single compute
   environment, job definition, and queue, replacing the console-managed resources. This ADR plus
   `docs/usage/aws_batch.md` are the spec.
+  - **Status: Phase 1 actioned.** See
+    [`0004-aws-batch-iac-terraform.md`](0004-aws-batch-iac-terraform.md) — Terraform now manages the
+    compute environment and job queue. The job definition remains CLI-managed (deferred to a
+    follow-up in that ADR) because it's re-registered with a new image digest on every deploy,
+    which would conflict with Terraform ownership.
 - **Optional dynamic resource validation** — query the Batch/ECS API for the compute
   environment's real capabilities instead of the static matrix. Needs live AWS credentials and is
   heavier; only worth it if the static table proves to drift painfully.

--- a/docs/architecture/adr/0004-aws-batch-iac-terraform.md
+++ b/docs/architecture/adr/0004-aws-batch-iac-terraform.md
@@ -92,6 +92,11 @@ Because this is Phase 1, the following are explicit, tracked gaps rather than ov
   bootstrap stack.
 - **No CI apply.** All `terraform apply` runs are manual, from an operator's machine, until a
   follow-up decision adds automation.
+- **Run with deployer-level credentials, not the federated `runzi-admin` session.** Provisioning
+  the compute environment + queue is a deployer/devops activity — same posture as
+  `terraform/access/`. The `runzi-admin` access tier does **not** hold Terraform-state access
+  (removed in PR #315 per ADR-0005's least-privilege followup), so it cannot run this root in any
+  case. Use the same deployer credentials that run `sls deploy` / `terraform/access/`.
 
 ## Followups not blocking this decision
 

--- a/docs/architecture/adr/0004-aws-batch-iac-terraform.md
+++ b/docs/architecture/adr/0004-aws-batch-iac-terraform.md
@@ -1,0 +1,121 @@
+# AWS Batch IaC: Terraform for the compute environment and queue (Phase 1)
+
+## Decision
+
+**runzi adopts Terraform, in this repo, to manage the two genuinely static AWS Batch
+resources: the Fargate compute environment and the `BasicFargate_Q` job queue.** State lives
+in a dedicated S3 bucket with native S3 locking (`use_lockfile`, Terraform ≥ 1.10); GNS operators
+run `terraform apply` from their own machines. There is no CI-driven apply yet.
+
+**The job definition (`Fargate-runzi-opensha-JD`) is explicitly out of scope for this phase** and
+stays managed by the existing `runzi utils docker-build` CLI flow. Owning it in Terraform is a
+tracked follow-up, not part of this decision.
+
+This actions the IaC followup deferred in
+[`0003-aws-batch-compute-consolidation.md`](0003-aws-batch-compute-consolidation.md#followups-not-blocking-this-decision):
+*"Adopt infrastructure-as-code (Terraform or AWS CDK) to encode the single compute environment,
+job definition, and queue, replacing the console-managed resources."* This ADR narrows that to
+compute environment + queue for Phase 1, and explains why.
+
+## Two deciding inputs
+
+1. **The compute environment and queue are the resources with no source of truth.** They were
+   hand-created in the AWS console and are documented only in prose (the consolidation ADR and
+   `docs/usage/aws_batch.md`). They change rarely — sizing, subnets, security groups — which makes
+   them an ideal, low-risk Terraform target: define once, `import` the live resource, and from
+   then on `terraform plan` is the drift detector that prose can't be.
+2. **The job definition mutates on every deploy, which conflicts with Terraform ownership.**
+   `update_job_definition()` (`runzi/cli/build_and_deploy_container.py:140-185`) re-registers a
+   new job-definition revision pinned to the freshly-pushed image **digest**
+   (`NZSHM22_RUNZI_ECR_DIGEST`) on every `runzi utils docker-build`. If Terraform also owned this
+   resource, every deploy would drift Terraform's state and every `terraform apply` would fight
+   the CLI's re-registration. The image revision is an *application deployment* concern, not
+   static infrastructure — the two need different lifecycles, so this phase only Terraforms the
+   side that doesn't change every deploy.
+
+## Background
+
+Before this change, per
+[`0003-aws-batch-compute-consolidation.md`](0003-aws-batch-compute-consolidation.md), all three Batch
+resources (compute environment, job definition, job queue) were created and changed by hand in
+the AWS console, with the ADR and `docs/usage/aws_batch.md` as the only record of their intended
+shape. That ADR deferred IaC explicitly rather than block the Fargate consolidation on it.
+
+Other apps in the GNS Batch account (a small number of outliers) may submit to some of the same
+generically-named resources (`BasicFargate_Q`), but **runzi is the canonical app for configuring,
+launching, and saving Batch jobs**, so this repo is the appropriate home for the Terraform that
+manages them — rather than a separate infra repo, which would split the spec
+(`docs/usage/aws_batch.md`, the consolidation ADR) from its implementation for no benefit at
+runzi's current scale.
+
+### Why Terraform over CDK or CloudFormation
+
+- **Terraform** was chosen primarily because **adopting already-existing, hand-created resources
+  is its strongest case**: `terraform import` brings a live resource under management without
+  recreating it, and the subsequent `terraform plan` showing zero changes is a clean, verifiable
+  proof that the HCL matches reality. CDK and CloudFormation can import too, but through stacks,
+  which is a heavier unit than importing two standalone resources.
+- It is not AWS-only (no lock-in if the account strategy changes), and its declarative HCL is a
+  reasonable size for two resources without needing a general-purpose language (CDK's main
+  selling point, infra-as-Python, isn't a strong pull for a stack this small).
+- The trade-off accepted: Terraform requires managing its own state, unlike CloudFormation, which
+  AWS tracks for you. See the state backend decision below.
+
+### Why an S3 backend, not local state
+
+A local state file is the lowest-friction option but assumes exactly one operator forever, and
+that file must never be lost or it's recreate-or-reimport. Because more than one GNS operator may
+run `terraform apply` over time, state needs to be shared and lockable. AWS's S3 backend with
+native locking (`use_lockfile = true`, no DynamoDB table required on Terraform ≥ 1.10) is the
+standard, lowest-overhead way to do that. The state bucket itself is a one-time, out-of-band
+bootstrap (created once, the same way the Batch resources exist today) — accepted as the one
+chicken-and-egg step in adopting Terraform at all.
+
+CI-driven apply (GitHub Actions) was considered and explicitly deferred: it would require giving
+this app repo's CI AWS deploy credentials, which is a larger blast-radius change than this phase
+needs while there's no apply automation pressure yet.
+
+## Consequences / deferred obligations
+
+Because this is Phase 1, the following are explicit, tracked gaps rather than oversights:
+
+- **The job definition's structure (IAM role, `platformCapabilities`, env vars, sizing) remains
+  uncodified**, living only in whatever revision the CLI last registered plus the prose in
+  `docs/usage/aws_batch.md`. This is the same gap the consolidation ADR already accepted for that
+  resource; Phase 1 does not close it.
+- **Discovering and importing the live compute-environment and queue config requires AWS
+  console/CLI access** (exact compute-environment name, `maxVcpus`, subnets, security groups,
+  queue priority) that must be gathered by an operator with credentials before `terraform import`
+  can run. See `terraform/batch/README.md` for the discovery commands.
+- **The S3 state bucket is a manual, out-of-band resource** (not Terraform-managed, for the
+  obvious bootstrap reason) until/unless a future change brings it under a higher-level
+  bootstrap stack.
+- **No CI apply.** All `terraform apply` runs are manual, from an operator's machine, until a
+  follow-up decision adds automation.
+
+## Followups not blocking this decision
+
+- **Own the job definition in Terraform.** Once this phase is proven, decide between (a) leaving
+  it CLI-managed permanently, or (b) bringing it under Terraform with the image digest as a
+  `terraform apply -var` input, with the CLI driving that apply so deploys stay one command. This
+  is a larger change to `build_and_deploy_container.py` and deserves its own review.
+- **Retire `BigLever_32GB_8VCPU_v2_*`** (the consolidation ADR's pending manual cleanup) — done by
+  hand in the console, not via Terraform, since we don't import resources slated for deletion.
+- **CI-driven `terraform apply`**, if/when operators want deploys automated — needs a decision on
+  granting AWS credentials to this repo's CI.
+- **Bring the state bucket itself under IaC** (e.g. a tiny bootstrap module) if a second Terraform
+  root ever needs the same backend.
+
+## Files
+
+- `docs/architecture/adr/0003-aws-batch-compute-consolidation.md` — the prior ADR this one actions
+  the IaC followup of.
+- `docs/usage/aws_batch.md` — updated to describe the Terraform-managed resources and link the
+  runbook.
+- `terraform/batch/` — the new Terraform root: `versions.tf`, `backend.tf`, `providers.tf`,
+  `variables.tf`, `main.tf`, and `README.md` (operator runbook: discovery commands, state bucket
+  bootstrap, init/import/plan/apply workflow).
+- `runzi/arguments.py` — `DEFAULT_JOB_QUEUE` / `DEFAULT_JOB_DEFINITION` remain the names Terraform
+  must match; unchanged by this phase.
+- `runzi/cli/build_and_deploy_container.py` — unchanged by this phase; remains the sole owner of
+  the job definition's image revision.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -18,4 +18,5 @@ and leave the file in place.
 | [0001](0001-cognito-identity-pool-role-mapping.md) | Cognito Identity Pool role mapping with multiple User Pool groups |
 | [0002](0002-aws-auth-decision.md) | AWS authentication: in-memory Cognito session vs `~/.aws/credentials` |
 | [0003](0003-aws-batch-compute-consolidation.md) | AWS Batch compute: consolidate to a single Fargate environment |
+| [0004](0004-aws-batch-iac-terraform.md) | AWS Batch IaC: Terraform for the compute environment and queue (Phase 1) |
 | [0005](0005-runzi-iam-tiers-terraform-migration.md) | Migrate runzi's IAM access-tier roles/policies into runzi/Terraform |

--- a/docs/usage/aws_batch.md
+++ b/docs/usage/aws_batch.md
@@ -1,6 +1,6 @@
 This describes the AWS Batch architecture `runzi` submits jobs to in `--cluster-mode AWS`. It is
 the operator-facing companion to the decision recorded in
-[`docs/architecture/aws-batch-compute-consolidation.md`](../architecture/aws-batch-compute-consolidation.md).
+[`docs/architecture/adr/0003-aws-batch-compute-consolidation.md`](../architecture/adr/0003-aws-batch-compute-consolidation.md).
 
 # Single Fargate architecture (default)
 
@@ -64,17 +64,17 @@ with margin below your largest instance's total memory, not right up against it.
 defaults `platformCapabilities` to `EC2` when omitted, which would silently break Fargate's
 fractional vCPU values, so this must always be forwarded explicitly.
 
-# Future: infrastructure-as-code
+# Infrastructure-as-code
 
-The compute environment, job definition, and job queue above are currently created and managed
-by hand in the AWS console — there is no Terraform/CDK/CloudFormation for them. This doc and the
-ADR are the interim source of truth.
+The **compute environment and `BasicFargate_Q` job queue** are managed by Terraform in
+[`terraform/batch/`](../../terraform/batch/) — see that directory's `README.md` for the operator
+runbook (discovery, state bucket, import, day-to-day `plan`/`apply`) and
+[`docs/architecture/adr/0004-aws-batch-iac-terraform.md`](../architecture/adr/0004-aws-batch-iac-terraform.md)
+for why.
 
-When IaC is adopted, it should encode:
-- The Fargate compute environment (`maxvCpus`, subnets, security groups)
-- The `Fargate-runzi-opensha-JD` job definition (image reference, IAM role, `platformCapabilities`,
-  the M2M env vars above)
-- The `BasicFargate_Q` job queue
-
-Until then, any change to these resources must be made manually in the console and reflected back
-into this doc.
+The **`Fargate-runzi-opensha-JD` job definition is still hand/CLI-managed**, not Terraform —
+it's re-registered with a new image digest on every `runzi utils docker-build` (see "Updating the
+job definition" above), which would conflict with Terraform ownership. Its IAM role,
+`platformCapabilities`, and the M2M env vars remain console-set and documented only here until a
+follow-up decision brings it under IaC too. Any change to the job definition must still be made
+manually/via the CLI and reflected back into this doc.

--- a/runzi/arguments.py
+++ b/runzi/arguments.py
@@ -28,7 +28,7 @@ class ComputeEnvironment(Enum):
 
 
 # Canonical AWS Batch compute target. All tasks share a single Fargate compute environment,
-# job definition, and queue (see docs/architecture/aws-batch-compute-consolidation.md).
+# job definition, and queue (see docs/architecture/adr/0003-aws-batch-compute-consolidation.md).
 DEFAULT_JOB_DEFINITION = "Fargate-runzi-opensha-JD"
 DEFAULT_JOB_QUEUE = "BasicFargate_Q"
 

--- a/terraform/batch/.gitignore
+++ b/terraform/batch/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+terraform.tfvars
+

--- a/terraform/batch/README.md
+++ b/terraform/batch/README.md
@@ -1,0 +1,90 @@
+# runzi AWS Batch Terraform (Phase 1)
+
+Manages the **Fargate compute environment** and **`BasicFargate_Q` job queue** that runzi
+submits AWS Batch jobs to. See
+[`docs/architecture/adr/0004-aws-batch-iac-terraform.md`](../../docs/architecture/adr/0004-aws-batch-iac-terraform.md)
+for the decision record, including why the job definition is deliberately **not** managed here.
+
+Run everything in this directory (`terraform/batch/`) — it's a standalone Terraform root.
+
+## Prerequisites
+
+- Terraform >= 1.10 (for native S3 state locking via `use_lockfile`).
+- AWS credentials with read access to Batch (for discovery/import) and write access to Batch,
+  matching whatever account/role you use to operate runzi's AWS Batch resources today.
+
+## One-time: state bucket bootstrap
+
+This root's state lives in S3 (`backend.tf`), but that bucket isn't created by this root — it's
+a manual, one-time bootstrap, the same way the Batch resources themselves were hand-created.
+
+Check whether it already exists before creating a new one:
+
+```bash
+aws s3 ls | grep tfstate
+```
+
+If it doesn't exist, create it once (versioning + public-access-block recommended):
+
+```bash
+aws s3api create-bucket --bucket nzshm22-runzi-tfstate --region us-east-1
+aws s3api put-bucket-versioning --bucket nzshm22-runzi-tfstate \
+  --versioning-configuration Status=Enabled
+aws s3api put-public-access-block --bucket nzshm22-runzi-tfstate \
+  --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+```
+
+Update `backend.tf`'s `bucket` value if you used a different name.
+
+## Discovery: find the live resource config
+
+Before writing/importing, capture the **exact** live config so `terraform plan` comes back clean
+after import — these become your `terraform.tfvars` values.
+
+```bash
+# Find the compute environment backing BasicFargate_Q
+aws batch describe-job-queues --job-queues BasicFargate_Q --region us-east-1
+
+# Then describe that compute environment by the name/ARN from the queue's
+# computeEnvironmentOrder
+aws batch describe-compute-environments --region us-east-1
+```
+
+From the output, note:
+- Compute environment **name**, `maxvCpus`, `subnets`, `securityGroupIds` → `compute_environment_name`, `max_vcpus`, `subnets`, `security_group_ids`
+- Job queue **priority** → `job_queue_priority`
+
+Copy `terraform.tfvars.example` to `terraform.tfvars` and fill these in (gitignored — it's
+environment-specific).
+
+## Adopting the existing resources
+
+```bash
+terraform init
+terraform import aws_batch_compute_environment.fargate <compute-environment-name>
+terraform import aws_batch_job_queue.fargate <BasicFargate_Q-arn>
+terraform plan
+```
+
+**`terraform plan` must show zero changes after import.** That's the proof the HCL faithfully
+describes the live resources — nothing will be destroyed or recreated. If it shows a diff, adjust
+`main.tf`/`terraform.tfvars` to match the live config (not the other way around) and re-plan
+until it's clean.
+
+## Day-to-day workflow
+
+```bash
+terraform plan    # review before any change
+terraform apply   # apply after review
+```
+
+Running jobs are unaffected by `plan`/`import` (state-only operations) and by a clean `apply`
+(no actual change to apply). Treat any non-empty `plan` on this root as worth understanding
+before applying — these resources back live job submission.
+
+## What this root does NOT manage
+
+- The job definition (`Fargate-runzi-opensha-JD`) — see the ADR for why.
+- IAM roles, VPC/subnets/security groups, the ECR repo, Secrets Manager secrets, Cognito — these
+  are referenced by ID/name via variables, not created or imported here.
+- The Terraform state bucket itself (bootstrapped manually, above).

--- a/terraform/batch/README.md
+++ b/terraform/batch/README.md
@@ -10,8 +10,11 @@ Run everything in this directory (`terraform/batch/`) — it's a standalone Terr
 ## Prerequisites
 
 - Terraform >= 1.10 (for native S3 state locking via `use_lockfile`).
-- AWS credentials with read access to Batch (for discovery/import) and write access to Batch,
-  matching whatever account/role you use to operate runzi's AWS Batch resources today.
+- **Deployer-level AWS credentials** — read+write to Batch (for discovery/import/apply) *and*
+  read/write to the `nzshm22-runzi-tfstate` state bucket. Run this with the same deployer
+  credentials used for `terraform/access/` / `sls deploy`, **not** the federated `runzi-admin`
+  session (which no longer holds Terraform-state access — see ADR-0005). Provisioning Batch infra
+  is a deployer/devops activity, not a runzi access-tier one.
 
 ## One-time: state bucket bootstrap
 

--- a/terraform/batch/backend.tf
+++ b/terraform/batch/backend.tf
@@ -1,0 +1,16 @@
+# State backend for the runzi AWS Batch Terraform root.
+#
+# The S3 bucket below is NOT managed by this Terraform root - it is a one-time, out-of-band
+# bootstrap (see terraform/batch/README.md), the same way the Batch resources themselves were
+# hand-created before this root existed. `use_lockfile` enables Terraform's native S3 locking
+# (Terraform >= 1.10), so no separate DynamoDB lock table is needed.
+#
+# Fill in `bucket` (and `key`/`region` if they differ) before running `terraform init`.
+terraform {
+  backend "s3" {
+    bucket       = "nzshm22-runzi-tfstate" # CONFIRM/CREATE - see README.md "State bucket bootstrap"
+    key          = "batch/terraform.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+  }
+}

--- a/terraform/batch/main.tf
+++ b/terraform/batch/main.tf
@@ -1,0 +1,31 @@
+# Phase 1 IaC scope: the Fargate compute environment and job queue only.
+#
+# The job definition (Fargate-runzi-opensha-JD) is deliberately NOT managed here - it is
+# re-registered with a new image digest on every `runzi utils docker-build`, which would
+# conflict with Terraform ownership. See docs/architecture/aws-batch-iac-terraform.md.
+#
+# IAM roles, VPC/subnets/security groups, the ECR repo, and secrets are referenced via the
+# variables above, not created or imported here - they belong to other systems/owners.
+
+resource "aws_batch_compute_environment" "fargate" {
+  name = var.compute_environment_name
+  type = "MANAGED"
+
+  compute_resources {
+    type               = "FARGATE"
+    max_vcpus          = var.max_vcpus
+    subnets            = var.subnets
+    security_group_ids = var.security_group_ids
+  }
+}
+
+resource "aws_batch_job_queue" "fargate" {
+  name     = var.job_queue_name
+  state    = "ENABLED"
+  priority = var.job_queue_priority
+
+  compute_environment_order {
+    order               = 1
+    compute_environment = aws_batch_compute_environment.fargate.arn
+  }
+}

--- a/terraform/batch/outputs.tf
+++ b/terraform/batch/outputs.tf
@@ -1,0 +1,7 @@
+output "compute_environment_arn" {
+  value = aws_batch_compute_environment.fargate.arn
+}
+
+output "job_queue_arn" {
+  value = aws_batch_job_queue.fargate.arn
+}

--- a/terraform/batch/providers.tf
+++ b/terraform/batch/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/batch/terraform.tfvars.example
+++ b/terraform/batch/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# Copy to terraform.tfvars and fill in with values discovered from the live AWS resources
+# (see README.md "Discovery"). terraform.tfvars is gitignored - it's environment-specific and
+# may contain account-specific identifiers that shouldn't live in version control.
+
+compute_environment_name = "TODO-discover-from-aws-batch-describe-compute-environments"
+max_vcpus                = 0 # TODO
+subnets                  = ["subnet-TODO"]
+security_group_ids       = ["sg-TODO"]
+job_queue_priority       = 1 # TODO - confirm against live queue

--- a/terraform/batch/variables.tf
+++ b/terraform/batch/variables.tf
@@ -1,0 +1,40 @@
+# Names below match runzi/arguments.py (DEFAULT_JOB_QUEUE, and the compute environment backing
+# it) and runzi/job_runner.py's hard-coded Batch region. Keep them in sync if either side changes.
+
+variable "aws_region" {
+  description = "AWS region Batch runs in (matches runzi/job_runner.py's hard-coded Batch client region)."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "compute_environment_name" {
+  description = "Name of the existing Fargate compute environment backing BasicFargate_Q. Discover with `aws batch describe-compute-environments` (see README.md) before import."
+  type        = string
+}
+
+variable "job_queue_name" {
+  description = "Name of the existing job queue. Matches runzi.arguments.DEFAULT_JOB_QUEUE."
+  type        = string
+  default     = "BasicFargate_Q"
+}
+
+variable "max_vcpus" {
+  description = "Compute environment max vCPUs. Must be high enough for the desired OQ hazard/disagg concurrency at 8 vCPU/job (see docs/architecture/aws-batch-compute-consolidation.md). Set to the live value discovered before import."
+  type        = number
+}
+
+variable "subnets" {
+  description = "Subnet IDs for the Fargate compute environment. Discover from the live compute environment before import."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security group IDs for the Fargate compute environment. Discover from the live compute environment before import."
+  type        = list(string)
+}
+
+variable "job_queue_priority" {
+  description = "Priority of the job queue. Discover from the live queue before import."
+  type        = number
+  default     = 1
+}

--- a/terraform/batch/versions.tf
+++ b/terraform/batch/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

AWS Batch compute IaC (Phase 1): a `terraform/batch/` root managing the **Fargate compute
environment + `BasicFargate_Q` queue** — the static, drift-prone, previously console-only
resources. Adopted via `terraform import` (nothing recreated); operator-run, nothing
auto-deploys. The job definition stays CLI-managed (it's re-registered with a new image digest
every deploy — would fight Terraform).

> **Stacked on the runzi IAM access PR — review/merge that one first.** This PR's diff is scoped
> to the batch work; GitHub will retarget its base to `main` once the IAM PR merges.

## What's in here

- `terraform/batch/` — the Fargate compute environment + queue, with an operator `README.md`.
- **ADR-0004** (the Batch IaC decision) and the `docs/usage/aws_batch.md` rewrite describing the
  Terraform-managed architecture.
- The batch-side bookkeeping from the ADR reorg done in the base PR: the relocated-ADR path
  references in `CHANGELOG.md` / `runzi/arguments.py`, the `0004` row in the ADR index, and
  ADR-0003's "Phase 1 actioned → 0004" followup note.

## How to review

Start with **ADR-0004** (`docs/architecture/adr/`), then `terraform/batch/main.tf` and
`terraform/batch/README.md`.
