### PR TITLE
Disable gql client schema fetching to fix DirectiveLocation crash

### DIFF
--- a/runzi/automation/azimuthal_rupture_set_builder_task.py
+++ b/runzi/automation/azimuthal_rupture_set_builder_task.py
@@ -45,10 +45,10 @@ class RuptureSetBuilderTask:
 
         if self.use_api:
             self._ruptgen_api = RuptureGenerationTask(
-                API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs()
+                API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs()
             )
-            self._general_api = GeneralTask(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+            self._general_api = GeneralTask(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def ruptureSetMetrics(self):
         metrics = {}

--- a/runzi/automation/inversion_hazard_report_task.py
+++ b/runzi/automation/inversion_hazard_report_task.py
@@ -26,7 +26,7 @@ class BuilderTask:
         self.use_api = job_args.get('use_api', False)
 
         if self.use_api:
-            self._toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
+            self._toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
         # setup the java gateway binding
         self._gateway = JavaGateway(gateway_parameters=GatewayParameters(port=job_args['java_gateway_port']))

--- a/runzi/automation/toshi_api/toshi_api.py
+++ b/runzi/automation/toshi_api/toshi_api.py
@@ -17,7 +17,7 @@ from .time_dependent_inversion_solution import TimeDependentInversionSolution
 
 
 class ToshiApi(ToshiClientBase):
-    def __init__(self, url, s3_url, auth_token, with_schema_validation=True, headers=None):
+    def __init__(self, url, s3_url, auth_token, with_schema_validation=False, headers=None):
         super().__init__(url, auth_token, with_schema_validation, headers)
         self._s3_url = s3_url
 

--- a/runzi/tasks/average_solutions/average_solutions_task.py
+++ b/runzi/tasks/average_solutions/average_solutions_task.py
@@ -102,8 +102,8 @@ class AverageSolutionsTask:
         self.output_folder = WORK_PATH
         self.model_type = model_type
 
-        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-        self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+        self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def run(self):
 

--- a/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
+++ b/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
@@ -33,7 +33,7 @@ logging.getLogger('git.cmd').setLevel(loglevel)
 
 
 def get_fault_model_file(fault_model_file_id) -> Path:
-    toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
+    toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
     file_generator = get_output_file_id(toshi_api, fault_model_file_id)
     fault_model_file_info = download_files(toshi_api, file_generator, str(WORK_PATH), overwrite=False)
     fault_model_archive_file_path = fault_model_file_info[fault_model_file_id]['filepath']
@@ -121,10 +121,10 @@ class CoulombRuptureSetBuilderTask:
 
         if self.use_api:
             self._ruptgen_api = RuptureGenerationTask(
-                API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs()
+                API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs()
             )
-            self._general_api = GeneralTask(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+            self._general_api = GeneralTask(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def ruptureSetMetrics(self):
         metrics = {}

--- a/runzi/tasks/inversion/inversion_solution_builder.py
+++ b/runzi/tasks/inversion/inversion_solution_builder.py
@@ -217,8 +217,8 @@ class InversionSolutionBuilder(ABC):
         # repos = ["opensha", "nzshm-opensha", "nzshm-runzi"]
         # self._repoheads = get_repo_heads(PurePath(job_args['root_folder']), repos)
         self.output_folder = WORK_PATH
-        self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
-        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
+        self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
+        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
         self.inversion_runner: JavaObject
 
     # the purpose of this method is simply to be explicit about creating the runner object.

--- a/runzi/tasks/inversion/inversion_sub_solution_task.py
+++ b/runzi/tasks/inversion/inversion_sub_solution_task.py
@@ -35,10 +35,10 @@ class BuilderTask:
         if self.use_api:
             # self._ruptgen_api = RuptureGenerationTask(
             #   API_URL, S3_URL,
-            #   None, with_schema_validation=True, **get_auth_kwargs()
+            #   None, with_schema_validation=False, **get_auth_kwargs()
             # )
-            self._toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+            self._toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def run(self, task_arguments, job_arguments):
         raise NotImplementedError("inversion sub solution uses removed solvis functions and does not work.")

--- a/runzi/tasks/inversion_report/inversion_diags_report_task.py
+++ b/runzi/tasks/inversion_report/inversion_diags_report_task.py
@@ -53,7 +53,7 @@ class InversionReportTask:
     def run(self):
 
         # download the file
-        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
+        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
         file_generator = get_output_file_id(self.toshi_api, self.solution_id)  # for file by file ID
         solutions = download_files(self.toshi_api, file_generator, str(WORK_PATH), overwrite=False)
         self.solution_info = solutions[self.solution_id]

--- a/runzi/tasks/oq_hazard/oq_disagg_runner.py
+++ b/runzi/tasks/oq_hazard/oq_disagg_runner.py
@@ -19,7 +19,7 @@ from runzi.tasks.oq_hazard.oq_hazard_task import get_locations_from_file
 
 
 def _upload_file(file_path: Path) -> str:
-    toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
+    toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
     file_id, post_url = toshi_api.file.create_file(file_path)
     toshi_api.file.upload_content(post_url, file_path)
     return file_id

--- a/runzi/tasks/oq_hazard/oq_disagg_task.py
+++ b/runzi/tasks/oq_hazard/oq_disagg_task.py
@@ -87,8 +87,8 @@ class OQDisaggTask:
         self.system_args = system_args
 
         if self.use_api:
-            self._toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+            self._toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def set_disaggregation_params(self):
         self.model.hazard_config.set_parameter("general", "calculation_mode", "disaggregation")

--- a/runzi/tasks/oq_hazard/oq_hazard_runner.py
+++ b/runzi/tasks/oq_hazard/oq_hazard_runner.py
@@ -16,7 +16,7 @@ from runzi.tasks.oq_hazard.hazard_args import OQHazardArgs
 
 
 def _upload_file(file_path: Path) -> str:
-    toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
+    toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
     file_id, post_url = toshi_api.file.create_file(file_path)
     toshi_api.file.upload_content(post_url, file_path)
     return file_id

--- a/runzi/tasks/oq_hazard/oq_hazard_task.py
+++ b/runzi/tasks/oq_hazard/oq_hazard_task.py
@@ -67,7 +67,7 @@ def get_locations_from_file(
     vs30s: list[int] = []
     with tempfile.TemporaryDirectory() as temp_dir:
         if locations_file_id:
-            file_api = ToshiFile(API_URL, None, None, with_schema_validation=True, **get_auth_kwargs())
+            file_api = ToshiFile(API_URL, None, None, with_schema_validation=False, **get_auth_kwargs())
             file_api.download_file(locations_file_id, target_dir=temp_dir, target_name="sites.csv")
             locations_file = Path(temp_dir) / "sites.csv"
         else:
@@ -90,8 +90,8 @@ class OQHazardTask:
         self.system_args = system_args
 
         if self.use_api:
-            self._toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+            self._toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+            self._task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def _setup_automation_task(self) -> str:
 

--- a/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
+++ b/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
@@ -42,8 +42,8 @@ class OQConvertTask:
         self.model_type = model_type
         self.use_api = system_args.use_api
 
-        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-        self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+        self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def convert(self, src_folder: Path) -> Path:
 

--- a/runzi/tasks/rupset_report/ruptset_diags_report_task.py
+++ b/runzi/tasks/rupset_report/ruptset_diags_report_task.py
@@ -50,7 +50,7 @@ class RupsetReportTask:
         rupture_set_id = self.user_args.source_solution_id
 
         # download the file
-        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
+        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
         file_generator = get_output_file_id(self.toshi_api, rupture_set_id)  # for file by file ID
         solutions = download_files(self.toshi_api, file_generator, str(WORK_PATH), overwrite=False)
         rupture_set_info = solutions[rupture_set_id]

--- a/runzi/tasks/scale_solution/scale_solution_task.py
+++ b/runzi/tasks/scale_solution/scale_solution_task.py
@@ -55,8 +55,8 @@ class ScaleSolutionTask:
         self.output_folder = WORK_PATH
 
         if self.use_api:
-            self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-            self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+            self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+            self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def run(self):
         # Run the task....

--- a/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
+++ b/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
@@ -82,10 +82,10 @@ class SubductionRuptureSetBuilderTask:
 
         if self.use_api:
             self.ruptgen_api = RuptureGenerationTask(
-                API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs()
+                API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs()
             )
-            self.general_api = GeneralTask(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-            self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+            self.general_api = GeneralTask(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+            self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def ruptureSetMetrics(self):
         return dict(

--- a/runzi/tasks/time_dependent_solution/time_dependent_solution_task.py
+++ b/runzi/tasks/time_dependent_solution/time_dependent_solution_task.py
@@ -64,8 +64,8 @@ class TimeDependentSolutionTask:
         self.gateway = JavaGateway(gateway_parameters=GatewayParameters(port=self.system_args.java_gateway_port))
         self.time_dependent_generator = self.gateway.entry_point.getTimeDependentRatesGenerator()
 
-        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
-        self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=True, **get_auth_kwargs())
+        self.toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
+        self.task_relation_api = TaskRelation(API_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     def run(self):
         # Run the task....

--- a/runzi/tasks/toshi_utils.py
+++ b/runzi/tasks/toshi_utils.py
@@ -7,7 +7,7 @@ from runzi.automation.toshi_api import ToshiApi
 
 
 def get_toshi_api() -> ToshiApi:
-    return ToshiApi(API_URL, None, None, with_schema_validation=True, **get_auth_kwargs())
+    return ToshiApi(API_URL, None, None, with_schema_validation=False, **get_auth_kwargs())
 
 
 def get_solution_ids_from_id(toshi_id):

--- a/runzi/tasks/utils/build_manual_index.py
+++ b/runzi/tasks/utils/build_manual_index.py
@@ -189,7 +189,7 @@ def build_manual_index(
     UPLOAD_FOLDER = "./DATA"
     TUI = "http://simple-toshi-ui.s3-website-ap-southeast-2.amazonaws.com/"
 
-    general_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
+    general_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
 
     try:
         node = general_api.get_general_task_subtask_files(general_task_id)

--- a/runzi/tasks/utils/save_file_archive.py
+++ b/runzi/tasks/utils/save_file_archive.py
@@ -55,7 +55,7 @@ def process_one_file(dry_run: bool, filepath: str | Path, tag: str | None = None
         log.info('archived %s in %s.', filepath, archive_path)
 
     if archive_path:
-        toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=True, **get_auth_kwargs())
+        toshi_api = ToshiApi(API_URL, S3_URL, None, with_schema_validation=False, **get_auth_kwargs())
         filename = Path(filepath).name
         meta = dict(filename=filename)
         if tag:


### PR DESCRIPTION
## Problem

Any toshi API call (file upload, task creation, etc.) crashes on connect with:

```
TypeError: deprecated locations must be specified as a collection of DirectiveLocation enum values.
```

The exception fires **before** the GraphQL operation is sent — during `gql`'s schema introspection on connect (`fetch_schema` → `build_client_schema` → `build_directive` → `GraphQLDirective.__init__`). The same payloads succeed in the toshi **GraphiQL web UI** because the browser's graphql-js handles the introspection and does no Python-side schema build.

### Root cause

A version skew: the toshi server's introspection advertises a `@deprecated` directive location that the installed `graphql-core 3.2.8` enum doesn't recognise, so `build_client_schema` rejects it. (Stack: `gql 4.0.0`, `graphql-core 3.2.8`, `nshm-toshi-client 1.3.1`.)

Constructing a client with `with_schema_validation=True` sets `fetch_schema_from_transport=True`, which forces that introspection on every connect. Critically, `nshm-toshi-client 1.3.1` **already comments out** the actual query validation (`self._client.validate(...)`), so `with_schema_validation=True` no longer validates anything — its only remaining effect is the crashing introspection round-trip. Every API-enabled path passed `True` explicitly, so all of them are broken against this server.

## Fix

Disable client-side schema fetching:

- `with_schema_validation=True` → `False` at all ~37 construction sites (`ToshiApi`, `GeneralTask`, `TaskRelation`, `ToshiFile`) across 20 files.
- Default to `False` in `ToshiApi.__init__` so future call sites are safe by default.

No functional loss (validation is already a no-op upstream); also removes a wasteful introspection round-trip on every connect.

## Verification

- `ruff check runzi` → all checks passed
- `pytest tests` → 184 passed
- `grep with_schema_validation=True runzi` → none remaining
- End-to-end re-run of the OQ hazard `_upload_file` → `create_file` path is the remaining manual check (requires live toshi auth).

## Follow-up (separate repo, optional)

Tracked upstream: **GNS-Science/nshm-toshi-client#57**. The dead `with_schema_validation` flag / commented-out `validate()` in `nshm-toshi-client` should be cleaned up there (default to `False`, or decouple the flag from schema fetching) so this stops being a footgun.
