### PR TITLE
Drop TerraformStateS3 grant from runzi-admin (least privilege)

### DIFF
--- a/docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md
+++ b/docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md
@@ -95,11 +95,17 @@ against `nshm-toshi-api` today.
   (`baseline/policy-*.json`, `role-*-*.json`), not `serverless.yml`. **Prod must be reconciled to
   its OWN baseline snapshot** — its console drift may differ from test's, so a single static
   `main.tf` will not fit both stages unchanged (see Followups: per-stage definitions).
-- **The intended additions are the one *deliberate* non-zero-diff.** `runzi-admin` needs
-  `batch:CreateJobQueue/UpdateJobQueue/DeleteJobQueue` (a `BatchQueueAdmin` statement) and a
-  `TerraformStateS3` statement to operate `terraform/batch/`. These are authored **only** in
+- **The intended addition is the *deliberate* non-zero-diff.** A `BatchQueueAdmin` statement
+  (`batch:CreateJobQueue/UpdateJobQueue/DeleteJobQueue`) is authored **only** in
   `terraform/access/main.tf` (never in `serverless.yml`), so the post-reconciliation
-  `terraform plan` shows exactly those two added statements, which `apply` then creates.
+  `terraform plan` shows that added statement, which `apply` then creates.
+- **No Terraform-state access on the federated roles.** An earlier `TerraformStateS3` grant
+  (`s3:*` on `nzshm22-runzi-tfstate`) was **removed**: `terraform/batch/` is run with **deployer
+  credentials** (the same way `terraform/access/` is — see "Who runs"), so the Cognito-federated
+  `runzi-admin` role must not hold write/delete on the Terraform state bucket. The Batch
+  compute-env/queue admin perms (`BatchAdmin` + `BatchQueueAdmin`) are the same class of
+  *provisioning* power and are flagged for the same review (see Followups) — they remain on the
+  role for now only because slimming them is a broader access-model change.
 - **Deploy #2 (de-template) is stage-conditional, because `serverless.yml` is shared.** Removing
   the 6 resource definitions outright would also drop them from un-migrated stages' templates on
   their next deploy (`Retain` → orphaned). So deploy #2 excludes the 6 **only for the migrating
@@ -124,11 +130,20 @@ against `nshm-toshi-api` today.
   whether the User Pool itself, the `toshi-readers`/`toshi-writers` groups (toshi-api's own
   access axis, as opposed to runzi's AWS axis), and the M2M client/secret belong in
   `nzshm-security` or stay with `nshm-toshi-api`. Tracked via a `nzshm-security` issue (see Files).
-- **Per-stage policy definitions (blocks prod).** `main.tf` currently encodes the *test* stage's
-  live (drifted) content. Because prod's console drift may differ, `main.tf` needs to express
-  per-stage policy bodies before prod can be migrated — e.g. a stage-keyed local/`for_each`, a
-  small per-stage module, or per-workspace `.tfvars` driving the statements. Decide the mechanism
-  when planning prod (after capturing a prod baseline snapshot).
+- **Prod was migrated by ALIGNING to test, not per-stage faithfully.** The prod baseline snapshot
+  showed prod's admin policy was the *clean serverless original* (`BatchAdmin`/`ECRAdmin`,
+  `nshm-runzi-*`, no `iam:PassRole`) while test had been hand-patched. Rather than encode both
+  stages' drift via per-stage `main.tf` definitions, the team chose to **bring prod up to test's
+  patched admin policy** — a deliberate prod privilege expansion (gains `iam:PassRole`, ECR
+  `nzshm22/*`, extra ECR reads). So `main.tf` stays single-bodied and prod's import is an
+  intentional admin-policy change, not a clean custody transfer. (If anyone later needs the
+  stages to genuinely diverge, the per-stage mechanism — stage-keyed locals — is the fallback.)
+- **Move provisioning perms off the federated runzi roles.** `TerraformStateS3` was already
+  removed (state access → deployer creds; `terraform/batch/` runs with deployer creds). The Batch
+  compute-env/queue admin perms (`BatchAdmin`, `BatchQueueAdmin`) and arguably `ECRAdmin` image
+  push are also *provisioning/build* powers, not *job-running* powers — the runzi-* tiers exist to
+  **use** the system, not provision it. A focused pass should move these to the deployer side and
+  reconsider what the `runzi-admin` tier is actually for (touches ADR-003 / ADR-0004).
 - **Tidy the console-editor Sids.** Once owned by Terraform, rename `VisualEditor0/1` to
   meaningful Sids (e.g. `BatchComputeAdmin`, `ECRAdmin`) as a deliberate, separately-reviewed
   change — kept verbatim during the migration only to guarantee a clean import.

--- a/terraform/access/MIGRATION_RUNBOOK.md
+++ b/terraform/access/MIGRATION_RUNBOOK.md
@@ -73,13 +73,12 @@ strictly read-only.
   # authenticated -> .../role/toshi-runzi-local-<stage>
   # rules, in order: runzi-admin -> admin role, runzi-batch -> batch role, runzi-local -> local role
   ```
-- **The admin policy does NOT yet contain the queue/state grants** (it gains them only at T2b).
-  Don't assume specific Sids — the live policy may be console-edited (the test stage had
-  `VisualEditor0/1` + `IAMAdmin`, not the `serverless.yml` names). Just confirm the additions are
+- **The admin policy does NOT yet contain the queue grant** (it gains `BatchQueueAdmin` only at
+  T2b). Don't assume specific Sids — the live policy may be console-edited (the test stage had
+  `VisualEditor0/1` + `IAMAdmin`, not the `serverless.yml` names). Just confirm the addition is
   absent:
   ```bash
-  grep -c TerraformStateS3 baseline/policy-admin.json   # expect 0
-  grep -c CreateJobQueue   baseline/policy-admin.json   # expect 0
+  grep -c CreateJobQueue baseline/policy-admin.json   # expect 0
   jq '[.. | .Sid? // empty]' baseline/policy-admin.json # eyeball what IS there (it's your
                                                         # reconciliation source at T2 — see Step 2)
   ```
@@ -142,9 +141,9 @@ terraform plan
 ```
 
 **Validate (T2, after import, before apply) — RECONCILE main.tf TO LIVE:**
-- The goal is a `terraform plan` showing **only** the intended additions: the admin policy
-  gaining a `BatchQueueAdmin` statement (`batch:CreateJobQueue/UpdateJobQueue/DeleteJobQueue`) and
-  a `TerraformStateS3` statement (authored only in Terraform — see ADR-0005).
+- The goal is a `terraform plan` showing **only** the intended addition: the admin policy
+  gaining a `BatchQueueAdmin` statement (`batch:CreateJobQueue/UpdateJobQueue/DeleteJobQueue`),
+  authored only in Terraform — see ADR-0005.
 - **Expect the first plan to show MORE than that.** The live resources can have **drifted from
   `serverless.yml`** (the test stage was hand-edited in the console — different Sids, extra
   `iam:PassRole`, an `nzshm22/*` ECR scope, a `STAGE` tag, and the M2M secret ARN in
@@ -153,7 +152,7 @@ terraform plan
 - **When it doesn't match, fix `main.tf` to mirror LIVE — never change the live resource to match
   the HCL.** The authoritative "live" is your **baseline snapshot** (`baseline/policy-*.json`,
   `role-*-*.json`): reproduce each live statement verbatim, then append only the two intended
-  additions. Re-run `terraform plan` and iterate until the only diff is those two additions. (See
+  addition. Re-run `terraform plan` and iterate until the only diff is that one addition. (See
   the worked example in ADR-0005 "Consequences" — this is per-stage; prod's drift may differ.)
 - Nothing has been applied yet, so the live AWS state is still pristine:
   ```bash
@@ -174,9 +173,9 @@ reviewed (nothing can drift between plan and apply).
 ```bash
 ./scripts/snapshot-access-tiers.sh "$STAGE" "$POOL_ID" after-apply
 diff -ru baseline after-apply
-# expect: the ONLY differences are in policy-admin.json — the added BatchQueueAdmin statement
-#         (the queue actions) and the new TerraformStateS3 statement. Everything else identical.
-grep -c TerraformStateS3 after-apply/policy-admin.json    # expect 1 (now present)
+# expect: the ONLY difference is in policy-admin.json — the added BatchQueueAdmin statement
+#         (the queue actions). Everything else identical.
+grep -c BatchQueueAdmin after-apply/policy-admin.json    # expect 1 (now present)
 ```
 
 ---

--- a/terraform/access/README.md
+++ b/terraform/access/README.md
@@ -56,7 +56,7 @@ to snapshot-and-`diff` at each checkpoint). Do `test` first and validate before 
 
 The short version: deploy #1 (Retain + de-reference) in `nshm-toshi-api` → `terraform import` the
 6 resources here and confirm a clean `plan` (one expected exception: the admin policy gains the
-`CreateJobQueue`/`UpdateJobQueue`/`DeleteJobQueue` + `TerraformStateS3` grants that live only in
+`CreateJobQueue`/`UpdateJobQueue`/`DeleteJobQueue` `BatchQueueAdmin` grant that lives only in
 Terraform) → `terraform apply tfplan` (a saved `plan -out`) → deploy #2 (de-template) in
 `nshm-toshi-api`. Order matters — reversing it deletes live IAM resources used for active logins.
 

--- a/terraform/access/main.tf
+++ b/terraform/access/main.tf
@@ -12,10 +12,11 @@
 #
 # ONE INTENTIONAL EXCEPTION: aws_iam_policy.runzi_admin keeps its three LIVE statements verbatim
 # (the console-edited VisualEditor0/1 + IAMAdmin, preserved exactly so they import zero-diff) and
-# appends two NEW statements authored only here - BatchQueueAdmin and TerraformStateS3 - which
-# runzi-admin needs to operate terraform/batch/. So the admin policy's import will NOT be
-# zero-diff: `terraform plan` shows exactly those two added statements, which apply then creates.
+# appends ONE NEW statement authored only here - BatchQueueAdmin - so the admin policy's import is
+# not zero-diff: `terraform plan` shows that added statement, which apply then creates.
 # (The live test policy diverged from serverless.yml - hand-edited; see ADR-0005 "Consequences".)
+# A `TerraformStateS3` grant was removed - terraform/batch/ runs with deployer creds, so the
+# federated runzi-admin role should not hold Terraform-state access (see ADR-0005 followups).
 
 data "aws_caller_identity" "current" {}
 
@@ -149,10 +150,14 @@ resource "aws_iam_policy" "runzi_admin" {
           "arn:aws:iam::${local.account_id}:role/toshi_batch_ECS_TaskExecution",
         ]
       },
-      # ── Two statements below are the intended Terraform-era additions (authored only here,
-      #    never in serverless). They are what `terraform plan` should show being ADDED.
+      # ── One NEW statement below is a Terraform-era addition (authored only here, never in
+      #    serverless). LEAST-PRIVILEGE NOTE: terraform/batch/ is run with DEPLOYER creds (like
+      #    terraform/access/), NOT the federated runzi-admin session — so a `TerraformStateS3`
+      #    grant (s3 on nzshm22-runzi-tfstate) was deliberately REMOVED here: Terraform-state
+      #    access belongs to the deployer, not a Cognito-federated role. The Batch compute-env /
+      #    queue admin perms (`BatchAdmin` + this `BatchQueueAdmin`) are the same kind of
+      #    provisioning power and are pending the same review (see ADR-0005 followups).
       {
-        # runzi-admin manages the Batch job queue via terraform/batch/.
         Sid    = "BatchQueueAdmin"
         Effect = "Allow"
         Action = [
@@ -161,22 +166,6 @@ resource "aws_iam_policy" "runzi_admin" {
           "batch:DeleteJobQueue",
         ]
         Resource = "*"
-      },
-      {
-        # Terraform state for terraform/batch/ in nzshm-runzi (S3 backend + native S3 locking,
-        # which writes/deletes a "<key>.tflock" object).
-        Sid    = "TerraformStateS3"
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:ListBucket",
-        ]
-        Resource = [
-          "arn:aws:s3:::nzshm22-runzi-tfstate",
-          "arn:aws:s3:::nzshm22-runzi-tfstate/*",
-        ]
       },
     ]
   })


### PR DESCRIPTION
## Summary

Removes the `TerraformStateS3` grant (`s3:Get/Put/Delete/List` on `nzshm22-runzi-tfstate`) from
the `runzi_admin` IAM policy. A Cognito-federated **access-tier** role assumed by scientists
shouldn't hold write/delete on the **Terraform state bucket** — that's a provisioning power that
belongs to the deployer/devops identity.

`terraform/batch/` is run with **deployer credentials** (the same way `terraform/access/` is), so
`runzi_admin` never needed state access in the first place.

## What changed

- `terraform/access/main.tf` — drop the `TerraformStateS3` statement; comments explain why.
- ADR-0005 — record the least-privilege decision + a "move provisioning perms off the federated
  roles" follow-up.
- Runbook + access README — the admin policy's one intended addition is now just `BatchQueueAdmin`.

## Scope / follow-ups

- `BatchAdmin` + `BatchQueueAdmin` (Batch compute-env/queue admin) are the **same class** of
  provisioning power and are flagged for the same review — they stay on the role for now (a
  broader access-model change touching ADR-003/0004).
- `ADR-0004` + `terraform/batch/README.md` still say "terraform/batch runs under `runzi-admin`";
  they live on the unmerged #313 branch and need a matching "deployer creds" update there
  (tracked follow-up).

## Sequencing (prerequisite for the prod migration)

Merge → operator `terraform apply` in the **test** workspace of `terraform/access/` (removes the
grant from test's live admin policy) → the prod migration then inherits the slimmer policy, so
prod is never granted a permission we'd pull back.
