### PR TITLE
fix(terraform/batch): use compute_environment_name for AWS provider v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+ - Terraform IaC for the AWS Batch Fargate compute environment and `BasicFargate_Q` job queue (`terraform/batch/`); the hand-created resources are adopted via `terraform import`, with `terraform plan` as the drift detector. The job definition stays CLI-managed. See `docs/architecture/adr/0004-aws-batch-iac-terraform.md`.
+ - Terraform IaC for runzi's IAM access tiers (`terraform/access/`), migrating the federated Cognito roles to code. See `docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md`.
+
 ### Changed
  - Consolidated AWS Batch compute config: tasks now inherit a single default Fargate job definition/queue instead of each hardcoding their own, and `get_ecs_job_config` validates memory/vcpu against the real Fargate size matrix (up to 16 vCPU) via `validate_fargate_resources`, replacing the inline assert table. See `docs/architecture/adr/0003-aws-batch-compute-consolidation.md`.
+ - Removed Terraform state (S3) access from the federated `runzi-admin` role (least privilege); Terraform roots run with deployer credentials. See `docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md`.
+
+### Fixed
+ - Disabled gql client schema fetching to avoid a `DirectiveLocation` crash against the Toshi API.
 
 ## [0.11.0] 2026-10-06
 

--- a/terraform/batch/.terraform.lock.hcl
+++ b/terraform/batch/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/batch/main.tf
+++ b/terraform/batch/main.tf
@@ -8,8 +8,8 @@
 # variables above, not created or imported here - they belong to other systems/owners.
 
 resource "aws_batch_compute_environment" "fargate" {
-  name = var.compute_environment_name
-  type = "MANAGED"
+  compute_environment_name = var.compute_environment_name
+  type                     = "MANAGED"
 
   compute_resources {
     type               = "FARGATE"


### PR DESCRIPTION
## What

Fixes the `aws_batch_compute_environment` resource argument in the `terraform/batch/` root: `name` → `compute_environment_name`. The bare `name` form is the AWS provider **v6** schema; the pinned `~> 5.0` provider (v5.100.0) rejects it with:

```
Error: Unsupported argument
  on main.tf line 11, in resource "aws_batch_compute_environment" "fargate":
  11:   name = var.compute_environment_name
An argument named "name" is not expected here.
```

Also commits `.terraform.lock.hcl` (created by `terraform init`), as the README instructs.

## Why

This blocked completing the Phase 1 AWS Batch IaC adoption (ADR-0004): `terraform plan` errored before it could run. With this fix, the live compute environment (`BasicManagedFargate`) and queue (`BasicFargate_Q`) import cleanly and `terraform plan` returns **"No changes"** — the ADR's proof that the HCL matches reality.

## Verification

Run from `terraform/batch/` with deployer credentials:

- `terraform init` ✅
- `terraform import aws_batch_compute_environment.fargate BasicManagedFargate` ✅
- `terraform import aws_batch_job_queue.fargate arn:aws:batch:us-east-1:461564345538:job-queue/BasicFargate_Q` ✅
- `terraform plan` ✅ → No changes (after a one-time benign in-place migration of the queue from the deprecated `compute_environments` attribute to the `compute_environment_order` block)
- `terraform state list` ✅ → both resources managed

## Notes

- The deprecated→modern queue attribute migration was applied once as a safe in-place `UpdateJobQueue` (0 destroyed); running jobs unaffected.
- `terraform.tfvars` is gitignored and was corrected locally to the live `BasicManagedFargate` config (the previously-typed values belonged to a different compute environment).