### PR TITLE
feat(access): least-privilege access tiers — substrate vs code (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
  - Consolidated AWS Batch compute config: tasks now inherit a single default Fargate job definition/queue instead of each hardcoding their own, and `get_ecs_job_config` validates memory/vcpu against the real Fargate size matrix (up to 16 vCPU) via `validate_fargate_resources`, replacing the inline assert table. See `docs/architecture/adr/0003-aws-batch-compute-consolidation.md`.
  - Removed Terraform state (S3) access from the federated `runzi-admin` role (least privilege); Terraform roots run with deployer credentials. See `docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md`.
+ - Tightened runzi access-tier IAM to least-privilege (substrate vs code): dropped the M2M secret read from the base policy and removed Batch compute-environment/queue provisioning from the federated `runzi-admin` role (now deployer/Terraform-only), keeping image push + job-definition publish self-serve. See `docs/architecture/adr/0006-runzi-access-tier-least-privilege.md`.
 
 ### Fixed
  - Disabled gql client schema fetching to avoid a `DirectiveLocation` crash against the Toshi API.

--- a/docs/architecture/adr/0006-runzi-access-tier-least-privilege.md
+++ b/docs/architecture/adr/0006-runzi-access-tier-least-privilege.md
@@ -1,0 +1,50 @@
+# Runzi access-tier least-privilege: substrate vs code
+
+## Decision
+
+Tighten the `terraform/access/` IAM ladder along a **substrate-vs-code** cleavage:
+
+- **Substrate** (IAM tiers, compute environments, job queues, tfstate bucket, capacity) — rare
+  changes, account-wide blast radius — is owned by the **deployer** (the 2 god-admins) via
+  Terraform.
+- **Code** (the runzi image and the job definition pointing at it) — constant changes,
+  runzi-only blast radius — is **self-serve** for scientists via the federated tiers.
+
+Concretely:
+- **base policy:** drop `M2MSecretRead`. The `toshi-m2m` secret is read by `nshm_toshi_client`
+  inside the Batch container (its task/job role), not by human/federated sessions; local auth is
+  Cognito-JWT only.
+- **batch policy:** unchanged (keep all `BatchSubmit` actions; they support interactive
+  monitor/cancel).
+- **admin policy:** keep code/publish (ECR push, `RegisterJobDefinition`, `iam:PassRole`); remove
+  substrate provisioning (`Create/Update/DeleteComputeEnvironment`, `Create/Update/DeleteJobQueue`);
+  drop unused (`ecr:CreateRepository`, `ecr:BatchDeleteImage`, `batch:DeregisterJobDefinition`);
+  rename console-editor Sids (`VisualEditor0` → `JobDefPublish`, `VisualEditor1` → `ECRPush`).
+
+**`runzi-admin` is kept, not retired** — it is the federated self-serve release tier that lets
+scientists publish code without holding deployer/god-admin credentials.
+
+## Two deciding inputs
+
+1. **Only 2 people hold deployer/god-admin credentials, and scientists must self-serve code
+   changes.** Making publishing deployer-only would bottleneck every code experiment behind those
+   2 admins. So the publish step (build/push image + register job def) stays on a federated tier.
+2. **Provisioning powers don't belong on a broadly-assumable federated role.** The same principle
+   that removed `TerraformStateS3` from `runzi-admin` (ADR-0005) applies to compute-env/queue
+   admin: these are substrate, done with deployer creds via `terraform/batch/`, never by runzi.
+
+## Consequences / deferred
+
+- Verified before apply: the container job role holds the M2M secret read; the deployer holds the
+  removed provisioning actions (see the implementation plan's pre-apply verification gate).
+- Resource-scoping refinements (ECR push to `nzshm22/runzi`; `RegisterJobDefinition`/`SubmitJob`
+  to specific ARNs) are deferred — some intersect the publish-workflow hardening (#324).
+- S3 stage-incorrect ARNs remain (#321); job-def ownership remains CLI-managed and self-serve,
+  which this ADR reinforces (#320).
+
+## Files
+
+- `terraform/access/main.tf` — the policy edits.
+- `docs/usage/access_tiers.md` — updated ladder description.
+- `docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md` — this actions its
+  "move provisioning perms off the federated runzi roles" and "tidy Sids" followups.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -20,3 +20,4 @@ and leave the file in place.
 | [0003](0003-aws-batch-compute-consolidation.md) | AWS Batch compute: consolidate to a single Fargate environment |
 | [0004](0004-aws-batch-iac-terraform.md) | AWS Batch IaC: Terraform for the compute environment and queue (Phase 1) |
 | [0005](0005-runzi-iam-tiers-terraform-migration.md) | Migrate runzi's IAM access-tier roles/policies into runzi/Terraform |
+| [0006](0006-runzi-access-tier-least-privilege.md) | Runzi access-tier least-privilege: substrate vs code |

--- a/docs/superpowers/specs/2026-06-30-runzi-access-tier-permissions-design.md
+++ b/docs/superpowers/specs/2026-06-30-runzi-access-tier-permissions-design.md
@@ -1,0 +1,121 @@
+# Runzi access-tier permission tightening (#318) — Design
+
+## Context
+
+The `terraform/access/` IAM ladder (`local ⊂ batch ⊂ admin`, see `main.tf`) was migrated
+faithfully from `nshm-toshi-api`'s `serverless.yml` (ADR-0005) — drift and all. Issue #318 asks
+us to tighten it to least-privilege. Two problems motivate this:
+
+1. **Some grants on the federated user roles aren't user concerns.** The base policy grants
+   `secretsmanager:GetSecretValue` for the `toshi-m2m` secret, and the admin policy grants
+   Batch **compute-environment** and **job-queue** provisioning — both flagged by ADR-0005 as
+   provisioning/machine powers that shouldn't sit on a broadly-assumable Cognito-federated role.
+2. **Org constraint:** only **2 people** hold deployer/god-admin AWS credentials, and a core goal
+   is that **scientists self-serve code/behaviour changes** (build/push a new image, point a job
+   definition at it) **without** bottlenecking on those 2 admins.
+
+**Intended outcome:** each tier grants only what its actor legitimately needs, organized around a
+**substrate-vs-code** cleavage — without removing scientists' ability to publish their own code.
+
+## Organizing principle: substrate vs code
+
+| Axis | Changes | Blast radius | Actor | Mechanism |
+|---|---|---|---|---|
+| **Substrate / infra** | rarely | account-wide | the 2 deployer/god-admins | Terraform |
+| **Code / behaviour** | constantly | runzi-only | scientists (self-serve) | runzi CLI + federated tiers |
+
+Substrate = IAM tiers, compute environments, job queues, tfstate bucket, capacity (`maxVcpus`).
+Code = the runzi image and the job definition that points at it.
+
+**`runzi-admin` is explicitly KEPT** (not retired): it is the federated *self-serve release tier*
+that lets scientists publish code on the **code** axis. We only strip its **substrate** powers.
+
+## Current state (`terraform/access/main.tf`)
+
+- **base**: `ECRRead`, `S3ReadWrite`, `M2MSecretRead`
+- **batch** (+): `BatchSubmit` (7 actions: SubmitJob, DescribeJobs, ListJobs, TerminateJob,
+  DescribeJobQueues, DescribeComputeEnvironments, DescribeJobDefinitions)
+- **admin** (+): `VisualEditor0` (compute-env create/delete/update + Register/DeregisterJobDefinition),
+  `VisualEditor1` (ECR push + CreateRepository + BatchDeleteImage), `IAMAdmin` (PassRole),
+  `BatchQueueAdmin` (queue create/update/delete)
+- **roles**: `local`=base, `batch`=base+batch, `admin`=base+batch+admin (cumulative)
+
+Evidence gathered (code-traced): runzi calls `batch:SubmitJob` (submit path) and
+`describe_job_definitions` + `register_job_definition` (only in `build_and_deploy_container.py`);
+ECR push via `docker push`; `iam:PassRole` is required by `register_job_definition`. There is
+**no** runzi caller of `get_secret`, compute-env/queue admin, `CreateRepository`,
+`BatchDeleteImage`, or `DeregisterJobDefinition`.
+
+## Target design
+
+### base policy (inherited by all tiers)
+- **KEEP** `ECRRead` (image pull) and `S3ReadWrite` (reports + THS store).
+  - *Note:* the S3 ARNs are hardcoded to `-test` buckets regardless of stage — a real bug, but
+    tracked separately in **#321**; out of scope here.
+- **DROP** `M2MSecretRead`. **[DECIDED]** The `toshi-m2m` secret is read by `nshm_toshi_client`
+  *inside the Batch container* (the container's task role), not by human/federated sessions; local
+  auth is Cognito-JWT only. This is a machine concern, not a user one.
+
+### batch policy (increment)
+- **UNCHANGED** — keep all 7 `BatchSubmit` actions. **[DECIDED]** runzi code only calls
+  `SubmitJob`, but the `Describe*`/`List`/`Terminate` actions support scientists monitoring and
+  cancelling their own jobs interactively, and are deliberately retained.
+
+### admin policy (increment) — the core change
+**KEEP (code / publish — self-serve):**
+- ECR push: `InitiateLayerUpload`, `UploadLayerPart`, `CompleteLayerUpload`, `PutImage`,
+  `BatchCheckLayerAvailability`, `BatchGetImage` (on `nzshm22/*`)
+- `batch:RegisterJobDefinition`
+- `iam:PassRole` on `toshi_batch_ECS_TaskExecution`
+
+**REMOVE (substrate → deployer):** **[DECIDED]**
+- `batch:CreateComputeEnvironment`, `DeleteComputeEnvironment`, `UpdateComputeEnvironment`
+- the entire `BatchQueueAdmin` statement (`batch:CreateJobQueue`, `UpdateJobQueue`,
+  `DeleteJobQueue`)
+
+**DROP (unused):** **[DECIDED]**
+- `ecr:CreateRepository`, `ecr:BatchDeleteImage` — no runzi caller
+- `batch:DeregisterJobDefinition` — no runzi caller
+
+**Sid cleanup:** **[DECIDED]** since these statements are being edited anyway, rename the
+console-editor Sids (`VisualEditor0` → `JobDefPublish`, `VisualEditor1` → `ECRPush`). This also
+actions the ADR-0005 "tidy console-editor Sids" followup.
+
+## Out of scope (tracked elsewhere)
+
+- S3 stage-incorrect ARNs → **#321**
+- Resource-scoping refinements (ECR push to `nzshm22/runzi` not `/*`; `RegisterJobDefinition` to
+  the runzi JD name; `SubmitJob` to queue+JD ARNs) — optional future tightening; some intersect
+  **#324**.
+- Publish-workflow hardening (experimental vs shared JD, promotion) → **#324**
+- Job-def ownership (CLI vs Terraform) → **#320**. Note: the self-serve constraint argues
+  *against* deployer-gated Terraform for the JD.
+- Retiring `runzi-admin` — **explicitly rejected** (would bottleneck scientists behind the 2 admins).
+
+## Prerequisites / verification before apply
+
+1. **Confirm the Batch container task/job role holds `secretsmanager:GetSecretValue` on
+   `toshi-m2m-*`** before removing `M2MSecretRead` from base — so batch auth can't break.
+2. **Confirm the deployer credential holds the compute-env + queue admin actions** being removed,
+   so provisioning isn't stranded. (Deployer is god-admin — almost certainly yes; confirm.)
+3. `terraform plan` shows *exactly* the intended diff and nothing else.
+
+## Implementation
+
+- Edit `terraform/access/main.tf` (single-bodied; applies to both stages per ADR-0005).
+- Apply per stage with **deployer** creds (test → validate → prod), following
+  `terraform/access/README.md` + `MIGRATION_RUNBOOK.md` patterns.
+- Write **ADR-0006** recording the substrate-vs-code decision and `runzi-admin` as the kept
+  self-serve release tier (per the project's ADR-before-significant-changes convention).
+
+## Verification (end-to-end)
+
+- `terraform plan/apply` diff matches intent: `M2MSecretRead` gone from base; compute-env actions
+  + `BatchQueueAdmin` gone from admin; unused actions trimmed; Sids renamed.
+- **Self-serve still works:** a `runzi-admin` scientist can still run `runzi utils docker-build`
+  (ECR push + register JD succeed).
+- **Substrate locked down:** the same scientist gets `AccessDenied` on
+  `aws batch create-compute-environment` / `create-job-queue` / `update-compute-environment`.
+- **Batch auth intact:** a submitted job still reads the M2M secret via the container's task role.
+- **User tiers intact:** `runzi-batch` can submit/monitor/cancel; `runzi-local` can pull image +
+  read/write S3.

--- a/docs/usage/access_tiers.md
+++ b/docs/usage/access_tiers.md
@@ -12,9 +12,15 @@ drift below a lower one:
 
 | Tier | Role | Managed policies attached | Grants |
 |---|---|---|---|
-| `local` | `toshi-runzi-local-<stage>` | base | ECR pull, S3 report read/write, M2M secret read |
+| `local` | `toshi-runzi-local-<stage>` | base | ECR pull, S3 report read/write |
 | `batch` | `toshi-runzi-batch-<stage>` | base + batch | + AWS Batch submit/describe/terminate |
-| `admin` | `toshi-runzi-admin-<stage>` | base + batch + admin | + Batch/ECR/Terraform-state administration |
+| `admin` | `toshi-runzi-admin-<stage>` | base + batch + admin | + publish: ECR image push, register job definition (`iam:PassRole`). **Not** infra provisioning — compute environments and queues are deployer/Terraform-only. |
+
+The split follows a **substrate-vs-code** model (see
+[ADR-0006](../architecture/adr/0006-runzi-access-tier-least-privilege.md)): scientists self-serve
+*code* (image + job definition) via the federated tiers, while *substrate* (compute environments,
+queues, IAM, state, capacity) is provisioned only by the deployer via Terraform. The M2M secret is
+read by the Batch container's own task role, not these federated user roles.
 
 If a user is in more than one `runzi-*` group, the **highest tier wins** — see
 [ADR-0001](../architecture/adr/0001-cognito-identity-pool-role-mapping.md) for the role-mapping

--- a/terraform/access/main.tf
+++ b/terraform/access/main.tf
@@ -28,7 +28,7 @@ locals {
 
 resource "aws_iam_policy" "runzi_base" {
   name        = "toshi-runzi-base-${var.stage}"
-  description = "Base runzi permissions (ECR pull, S3 read/write, M2M secret read) shared by all runzi tiers"
+  description = "Base runzi permissions (ECR pull, S3 read/write) shared by all runzi tiers"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -62,14 +62,6 @@ resource "aws_iam_policy" "runzi_base" {
           "arn:aws:s3:::nzshm22-static-reports-test",
           "arn:aws:s3:::nzshm22-static-reports-test/*",
         ]
-      },
-      {
-        Sid    = "M2MSecretRead"
-        Effect = "Allow"
-        Action = "secretsmanager:GetSecretValue"
-        # The toshi-m2m secret lives in the Cognito/toshi-api region (ap-southeast-2), NOT this
-        # root's IAM provider region (us-east-1). This matches the live policy.
-        Resource = "arn:aws:secretsmanager:ap-southeast-2:${local.account_id}:secret:toshi-m2m-*"
       },
     ]
   })

--- a/terraform/access/main.tf
+++ b/terraform/access/main.tf
@@ -1,22 +1,18 @@
 # Runzi's own AWS access-tier IAM policies and roles - a cumulative ladder (local ⊂ batch ⊂
 # admin) granting STS credentials for ECR pull, S3 report read/write, and AWS Batch
-# submit/admin. Faithfully migrated from nshm-toshi-api/serverless.yml
+# submit + code publish. Originally migrated from nshm-toshi-api/serverless.yml
 # (ToshiRunzi{Base,Batch,Admin}ManagedPolicy / ToshiRunzi{Local,Batch,Admin}Role) - see
 # docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md for why only these 6
-# resources move here, and why the Cognito Identity Pool + its role attachment stay in
+# resources live here, and why the Cognito Identity Pool + its role attachment stay in
 # nshm-toshi-api.
 #
-# IMPORTANT: keep this file byte-faithful to whatever is actually deployed in
-# nshm-toshi-api/serverless.yml at migration/import time for each stage - the success criterion
-# is `terraform plan` showing zero changes after import.
-#
-# ONE INTENTIONAL EXCEPTION: aws_iam_policy.runzi_admin keeps its three LIVE statements verbatim
-# (the console-edited VisualEditor0/1 + IAMAdmin, preserved exactly so they import zero-diff) and
-# appends ONE NEW statement authored only here - BatchQueueAdmin - so the admin policy's import is
-# not zero-diff: `terraform plan` shows that added statement, which apply then creates.
-# (The live test policy diverged from serverless.yml - hand-edited; see ADR-0005 "Consequences".)
-# A `TerraformStateS3` grant was removed - terraform/batch/ runs with deployer creds, so the
-# federated runzi-admin role should not hold Terraform-state access (see ADR-0005 followups).
+# LEAST-PRIVILEGE MODEL (substrate vs code) - see
+# docs/architecture/adr/0006-runzi-access-tier-least-privilege.md:
+# aws_iam_policy.runzi_admin grants only CODE/PUBLISH powers: register the Batch job definition
+# (JobDefPublish), push the runzi image to ECR (ECRPush), and pass the task-execution role
+# (IAMAdmin). SUBSTRATE provisioning - compute-environment and job-queue admin, and Terraform
+# state - is NOT here: it is done by terraform/batch/ with DEPLOYER creds, never the federated
+# runzi-admin role.
 
 data "aws_caller_identity" "current" {}
 
@@ -99,30 +95,24 @@ resource "aws_iam_policy" "runzi_admin" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
-      # ── Three statements below mirror the LIVE policy verbatim (console-edited; hence the
-      #    VisualEditor* Sids). They are preserved exactly so the import is zero-diff for them.
-      #    The live admin policy carries hand-applied permissions the serverless.yml never had —
-      #    notably iam:PassRole and ECR scoped to nzshm22/* (the real repo) — kept intentionally.
+      # ── Code/publish powers only (see ADR-0006). JobDefPublish + ECRPush let runzi-admin
+      #    scientists self-serve a new image + job-definition revision; IAMAdmin's iam:PassRole is
+      #    required by RegisterJobDefinition to embed the task-execution role. ECR is scoped to the
+      #    real nzshm22/* repo. Substrate (compute-env/queue/state) is deployer-only, not here.
       {
-        Sid    = "VisualEditor0"
+        Sid    = "JobDefPublish"
         Effect = "Allow"
         Action = [
-          "batch:DeregisterJobDefinition",
-          "batch:CreateComputeEnvironment",
-          "batch:DeleteComputeEnvironment",
           "batch:RegisterJobDefinition",
-          "batch:UpdateComputeEnvironment",
         ]
         Resource = "*"
       },
       {
-        Sid    = "VisualEditor1"
+        Sid    = "ECRPush"
         Effect = "Allow"
         Action = [
-          "ecr:CreateRepository",
           "ecr:BatchGetImage",
           "ecr:CompleteLayerUpload",
-          "ecr:BatchDeleteImage",
           "ecr:UploadLayerPart",
           "ecr:InitiateLayerUpload",
           "ecr:BatchCheckLayerAvailability",
@@ -141,23 +131,6 @@ resource "aws_iam_policy" "runzi_admin" {
         Resource = [
           "arn:aws:iam::${local.account_id}:role/toshi_batch_ECS_TaskExecution",
         ]
-      },
-      # ── One NEW statement below is a Terraform-era addition (authored only here, never in
-      #    serverless). LEAST-PRIVILEGE NOTE: terraform/batch/ is run with DEPLOYER creds (like
-      #    terraform/access/), NOT the federated runzi-admin session — so a `TerraformStateS3`
-      #    grant (s3 on nzshm22-runzi-tfstate) was deliberately REMOVED here: Terraform-state
-      #    access belongs to the deployer, not a Cognito-federated role. The Batch compute-env /
-      #    queue admin perms (`BatchAdmin` + this `BatchQueueAdmin`) are the same kind of
-      #    provisioning power and are pending the same review (see ADR-0005 followups).
-      {
-        Sid    = "BatchQueueAdmin"
-        Effect = "Allow"
-        Action = [
-          "batch:CreateJobQueue",
-          "batch:UpdateJobQueue",
-          "batch:DeleteJobQueue",
-        ]
-        Resource = "*"
       },
     ]
   })

--- a/terraform/access/main.tf
+++ b/terraform/access/main.tf
@@ -23,8 +23,12 @@ locals {
 # ── Managed policies (the increments) ──────────────────────────────────────────────────────
 
 resource "aws_iam_policy" "runzi_base" {
-  name        = "toshi-runzi-base-${var.stage}"
-  description = "Base runzi permissions (ECR pull, S3 read/write) shared by all runzi tiers"
+  name = "toshi-runzi-base-${var.stage}"
+  # Description kept verbatim (it still says "M2M secret read") on purpose: aws_iam_policy.description
+  # is ForceNew, so changing it would destroy+recreate this policy — which is attached to all three
+  # runzi roles. The M2MSecretRead *statement* is removed from the document below (see ADR-0006);
+  # the stale word in the description is the lesser evil vs. a replace of a live, attached policy.
+  description = "Base runzi permissions (ECR pull, S3 read/write, M2M secret read) shared by all runzi tiers"
 
   policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
Closes #318.

## What

Tightens the `terraform/access/` IAM ladder along a **substrate-vs-code** cleavage (ADR-0006):

- **base policy:** drop `M2MSecretRead`. The `toshi-m2m` secret is read by `nshm_toshi_client` *inside the Batch container* (its task/job role), not by human/federated sessions (local auth is Cognito-JWT only).
- **batch policy:** unchanged (keep all `BatchSubmit` actions — they support interactive monitor/cancel).
- **admin policy:** keep code/publish (ECR push, `RegisterJobDefinition`, `iam:PassRole`); **remove** substrate provisioning (`Create/Update/DeleteComputeEnvironment`, `Create/Update/DeleteJobQueue`); drop unused (`ecr:CreateRepository`, `ecr:BatchDeleteImage`, `batch:DeregisterJobDefinition`); rename console-editor Sids (`VisualEditor0` → `JobDefPublish`, `VisualEditor1` → `ECRPush`).

`runzi-admin` is **kept**, not retired — it's the federated self-serve release tier so scientists can publish code without deployer/god-admin creds.

## Why

Only 2 people hold deployer/god-admin credentials, and scientists must self-serve **code** changes (build/push image + register job def) without bottlenecking on them. **Substrate** (compute envs, queues, IAM, state, capacity) is rare, account-wide, and stays deployer/Terraform-only — the same principle that removed `TerraformStateS3` from `runzi-admin` (ADR-0005). Actions ADR-0005's "move provisioning perms off the federated roles" + "tidy Sids" followups.

## Contents

- `docs/architecture/adr/0006-runzi-access-tier-least-privilege.md` (+ index)
- `terraform/access/main.tf` — the policy edits
- `docs/usage/access_tiers.md` — ladder update
- `docs/superpowers/specs/2026-06-30-runzi-access-tier-permissions-design.md` — design spec

`terraform validate` + `fmt` clean.

## ⚠️ Not yet applied — deployer action required before/at merge

This PR is the reviewable change only; nothing is applied. A **deployer** must run (with deployer creds — `runzi-admin` cannot, it has no tfstate access):

1. **Pre-apply gate:** confirm the Batch container job role can read `toshi-m2m-*`, and the deployer holds the provisioning actions being removed (`aws iam simulate-principal-policy`).
2. **Apply per stage** (test → validate → prod): `terraform plan`/`apply` in `terraform/access/`, then `simulate-principal-policy` to confirm substrate is denied / publish is allowed on `toshi-runzi-admin-*`.

Full step-by-step in `docs/superpowers/plans/2026-06-30-access-tier-permissions.md` (untracked locally).

## Out of scope (tracked)

- S3 stage-incorrect ARNs → #321
- Publish-workflow hardening (experimental vs shared JD) → #324
- Job-def ownership → #320