### PR TITLE
fix(access): make base-policy S3 ARNs stage-correct (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  - Tightened runzi access-tier IAM to least-privilege (substrate vs code): dropped the M2M secret read from the base policy and removed Batch compute-environment/queue provisioning from the federated `runzi-admin` role (now deployer/Terraform-only), keeping image push + job-definition publish self-serve. See `docs/architecture/adr/0006-runzi-access-tier-least-privilege.md`.
 
 ### Fixed
+ - Stage-incorrect S3 ARNs in the `terraform/access/` base policy: the runzi tiers' data-bucket grant was hardcoded to the `-test` buckets regardless of stage, so the `prod` roles targeted the test buckets. Now resolved per stage via stage-keyed `local.s3_data_buckets` (`prod` → `ths-dataset-prod` / `nzshm22-static-reports`; `test` unchanged). See `docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md` (#321).
  - Disabled gql client schema fetching to avoid a `DirectiveLocation` crash against the Toshi API.
 
 ## [0.11.0] 2026-10-06

--- a/docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md
+++ b/docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md
@@ -113,10 +113,12 @@ root.
   their next deploy (`Retain` → orphaned). So deploy #2 excludes the 6 **only for the migrating
   stage** via `serverslessIfElse`, keeping the definitions active for the others until each is
   migrated. See `MIGRATION_RUNBOOK.md` Step 3.
-- **The base policy's S3 ARNs are stage-incorrect today** (hardcoded to `-test` buckets
-  regardless of stage — flagged in toshi-api's ADR-003). This migration imports that bug
+- **The base policy's S3 ARNs were stage-incorrect at migration time** (hardcoded to `-test`
+  buckets regardless of stage — flagged in toshi-api's ADR-003). This migration imported that bug
   faithfully rather than fixing it in-flight, to keep the custody transfer itself low-risk and
-  verifiable by a zero-diff plan. Fixing it is a deliberate follow-up.
+  verifiable by a zero-diff plan. **Fixed as a deliberate follow-up in #321** via stage-keyed
+  locals (`local.s3_data_buckets`); prod now targets `ths-dataset-prod` / `nzshm22-static-reports`
+  while `test` stays zero-diff.
 - **Two coordination tickets are required** (one per repo) because the toshi-api side of the
   handoff (`sls deploy` retain/de-reference, then later de-template) is run by the team, not by
   this repo's tooling. See Files for the issues opened.
@@ -153,7 +155,8 @@ root.
   live test policy (different Sids/ECR glob, no `iam:PassRole`) — moot for migrated stages but
   worth reconciling; and the `serverslessIfElse` block has a stale `resourcee.Resources.*` typo
   (the runzi exclusions use the correct `resources.Resources.*` path).
-- **Fix the stage-incorrect S3 ARNs** in the base policy once Terraform owns it.
+- ~~**Fix the stage-incorrect S3 ARNs** in the base policy once Terraform owns it.~~ Done in #321
+  (stage-keyed `local.s3_data_buckets` in `terraform/access/main.tf`).
 - **CI-driven `terraform apply`** for `terraform/access/`, if/when the team wants it automated.
 
 ## Files

--- a/terraform/access/main.tf
+++ b/terraform/access/main.tf
@@ -18,6 +18,19 @@ data "aws_caller_identity" "current" {}
 
 locals {
   account_id = data.aws_caller_identity.current.account_id
+
+  # Data buckets the runzi tiers read/write. Names do NOT follow a <root>-<stage> convention
+  # (standardizing them has a large blast radius — out of scope, see #321), so encode them per
+  # stage explicitly rather than interpolating var.stage. This is the stage-keyed-locals fallback
+  # blessed by ADR-0005.
+  s3_data_buckets = {
+    test = ["ths-poc-arrow-test", "nzshm22-static-reports-test"]
+    prod = ["ths-dataset-prod", "nzshm22-static-reports"]
+  }
+  s3_data_bucket_arns = flatten([
+    for b in local.s3_data_buckets[var.stage] :
+    ["arn:aws:s3:::${b}", "arn:aws:s3:::${b}/*"]
+  ])
 }
 
 # ── Managed policies (the increments) ──────────────────────────────────────────────────────
@@ -54,14 +67,9 @@ resource "aws_iam_policy" "runzi_base" {
           "s3:ListBucket",
           "s3:PutObjectAcl",
         ]
-        # NOTE: hardcoded to the -test buckets regardless of stage - migrated faithfully from
-        # the live (buggy) policy. See ADR 0005 "Fix the stage-incorrect S3 ARNs" followup.
-        Resource = [
-          "arn:aws:s3:::ths-poc-arrow-test",
-          "arn:aws:s3:::ths-poc-arrow-test/*",
-          "arn:aws:s3:::nzshm22-static-reports-test",
-          "arn:aws:s3:::nzshm22-static-reports-test/*",
-        ]
+        # Stage-correct data-bucket ARNs (see local.s3_data_buckets). Fixes the previously
+        # hardcoded -test buckets (#321 / ADR-0005 deferred obligation).
+        Resource = local.s3_data_bucket_arns
       },
     ]
   })


### PR DESCRIPTION
## Summary

Fixes the stage-incorrect S3 ARNs in the `terraform/access/` base policy (the ADR-0005 deferred obligation).

The runzi tiers' S3 data-bucket grant (`aws_iam_policy.runzi_base`, `S3ReadWrite` statement) was hardcoded to the `-test` buckets regardless of `var.stage`. So the **prod** federated roles read/wrote the **test** data buckets and had no access to their own. This was imported faithfully during the ADR-0005 Terraform migration to keep the custody transfer verifiable by a zero-diff `terraform plan`, and deferred as a followup.

Because the bucket names do **not** follow a `<root>-<stage>` convention (standardizing them has a large blast radius — out of scope), the names are encoded explicitly per stage via a stage-keyed `local.s3_data_buckets` map — the fallback mechanism ADR-0005 names:

| Stage | Arrow / THS RLZ bucket | Static reports bucket |
|-------|------------------------|------------------------|
| test  | `ths-poc-arrow-test`   | `nzshm22-static-reports-test` |
| prod  | `ths-dataset-prod`     | `nzshm22-static-reports` |

`test` remains byte-identical (zero diff); only `prod` changes.

## Changes
- `terraform/access/main.tf` — stage-keyed `local.s3_data_buckets` + `local.s3_data_bucket_arns`; `S3ReadWrite` `Resource` now references the local.
- `docs/architecture/adr/0005-...md` — marks the deferred obligation resolved.
- `CHANGELOG.md` — `Fixed` entry.

## Verification
- `terraform fmt -check` + `terraform validate`: pass.
- `terraform plan` (test workspace): **No changes** (zero-diff).
- `terraform plan` (prod workspace): only the `aws_iam_policy.runzi_base` S3 ARNs change.
- **Applied to prod** with deployer credentials.

Closes #321.