### PR TITLE
feat(batch): read-only `runzi batch status` for general-task jobs (#326)

### DIFF
--- a/docs/usage/aws_batch.md
+++ b/docs/usage/aws_batch.md
@@ -98,6 +98,33 @@ runzi resolves whichever job definition you submit to back to a concrete image d
 time and records it (`NZSHM22_RUNZI_ECR_DIGEST`) in toshi provenance, so a run pins exactly which
 image it used even though the definition names only a tag.
 
+# Inspecting jobs (`runzi batch`)
+
+Federated Cognito users have no AWS console access, so `runzi batch` surfaces the state of the jobs
+a submission produced. When you submit in `--cluster-mode AWS`, runzi prints a `GENERAL_TASK_ID`;
+pass it to:
+
+```bash
+runzi batch status <GENERAL_TASK_ID>
+```
+
+This lists every Batch job for that general task (across both the Fargate and EC2 queues) with its
+status, run duration, and creation time. It is read-only and needs only the `batch:ListJobs` /
+`batch:DescribeJobs` permissions already granted to the `runzi-batch` access tier — log in with
+`toshi-auth login` first.
+
+**How it finds the jobs — a naming contract.** AWS Batch `list_jobs` can filter by queue and by a
+job-name prefix, but not by tags or the container config. So at submit time runzi encodes a
+sanitised `general_task_id` token as the **prefix** of each Batch job name
+(`<gt-token>-<base>-<task_count>`; see `runzi/aws/batch_query.py:batch_job_name`), and `status`
+queries with a `JOB_NAME` `<gt-token>-*` filter. Any future change to job naming **must preserve
+this prefix**, or `runzi batch status` will stop finding jobs.
+
+**Caveats.** AWS Batch retains terminal (SUCCEEDED/FAILED) jobs for only ~24h, so older jobs won't
+appear. The name encoding is also forward-only — jobs submitted before this feature shipped are not
+discoverable. (Terminate, log-fetching, and config decode are intentionally out of scope for this
+read-only version; log-fetching would additionally require a `logs:GetLogEvents` grant.)
+
 # Infrastructure-as-code
 
 Both the **Fargate** (compute env, `BasicFargate_Q`, `runzi-fargate-*` definitions) and **EC2**

--- a/runzi/aws/batch_query.py
+++ b/runzi/aws/batch_query.py
@@ -1,0 +1,89 @@
+"""Read-only AWS Batch inspection for federated Cognito users who have no console access (issue #326).
+
+The only linkage from an AWS Batch job back to a runzi general task is a token encoded into the
+Batch **job name** at submit time (``batch_job_name``). AWS Batch ``list_jobs`` can filter by queue +
+job-name prefix, so this token makes a general task's jobs discoverable without ``describe_jobs`` and
+without arbitrary tags (which ``list_jobs`` cannot filter on).
+"""
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from runzi.arguments import DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE
+from runzi.aws.session import get_session
+
+if TYPE_CHECKING:
+    import boto3
+
+# Mirror the batch client construction in runzi/job_runner.py:run_jobs().
+_BATCH_REGION = 'us-east-1'
+_BATCH_ENDPOINT = 'https://batch.us-east-1.amazonaws.com'
+
+
+def general_task_id_token(gt_id: str) -> str:
+    """Return a Batch-job-name-safe token for a toshi general_task_id.
+
+    Batch job names allow ``[A-Za-z0-9_-]`` only. A toshi id is base64 of ``GeneralTask:<int>``, so it
+    can contain ``+``, ``/`` and ``=`` padding. We map both ``+`` and ``/`` to ``_`` (deliberately not
+    ``-``) and strip ``=`` padding, so the token contains no ``-``. That leaves ``-`` free to act as an
+    unambiguous delimiter in ``batch_job_name`` — a ``{token}-*`` prefix filter can then never
+    false-match a different general task's job name.
+    """
+    return gt_id.replace('+', '_').replace('/', '_').replace('=', '')
+
+
+def batch_job_name(gt_id: str | None, base: str, task_count: int) -> str:
+    """Compose the Batch job name, encoding the general_task_id as a discoverable prefix.
+
+    Shared by the submitter (``build_tasks``) and the query side so both agree on the format. This is a
+    naming contract: ``jobs_for_general_task`` filters on the ``{token}-`` prefix, so any future change
+    to job naming must preserve it. When ``gt_id`` is ``None`` (e.g. non-API runs) we fall back to the
+    legacy ``{base}-{task_count}`` form and the job is simply not discoverable by general task.
+    """
+    if gt_id is None:
+        return f'{base}-{task_count}'
+    return f'{general_task_id_token(gt_id)}-{base}-{task_count}'
+
+
+def job_duration(summary: dict[str, Any], now_ms: int | None = None) -> str:
+    """Human-readable ``H:MM:SS`` run duration from a Batch JobSummary's epoch-millis timestamps.
+
+    A running job (started, not stopped) counts up to ``now``; a terminal job uses ``stoppedAt``; a job
+    that has not started yet has no meaningful duration (``-``).
+    """
+    started = summary.get('startedAt')
+    if started is None:
+        return '-'
+    stopped = summary.get('stoppedAt')
+    if stopped is None:
+        stopped = now_ms if now_ms is not None else int(time.time() * 1000)
+    seconds = max(0, (stopped - started) // 1000)
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    return f'{hours}:{minutes:02d}:{secs:02d}'
+
+
+def jobs_for_general_task(
+    gt_id: str,
+    session: 'boto3.Session | None' = None,
+    queues: tuple[str, ...] = (DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE),
+) -> list[dict[str, Any]]:
+    """Return the Batch JobSummary dicts for a general task, across all runzi queues.
+
+    Filters ``list_jobs`` by the ``{token}-`` job-name prefix. A JOB_NAME filter makes ``list_jobs``
+    return jobs of every status (not just RUNNING), and JobSummary already carries status plus the
+    created/started/stopped timestamps, so no ``describe_jobs`` call is needed for a status view.
+    Results are merged across queues and sorted oldest-first by ``createdAt``.
+    """
+    client = (session or get_session()).client(
+        service_name='batch', region_name=_BATCH_REGION, endpoint_url=_BATCH_ENDPOINT
+    )
+    name_filter = [{'name': 'JOB_NAME', 'values': [f'{general_task_id_token(gt_id)}-*']}]
+    paginator = client.get_paginator('list_jobs')
+
+    jobs: list[dict[str, Any]] = []
+    for queue in queues:
+        for page in paginator.paginate(jobQueue=queue, filters=name_filter):
+            jobs.extend(page.get('jobSummaryList', []))
+    jobs.sort(key=lambda job: job.get('createdAt', 0))
+    return jobs

--- a/runzi/build_tasks.py
+++ b/runzi/build_tasks.py
@@ -23,6 +23,7 @@ from runzi.automation.local_config import (
 from runzi.automation.opensha_task_factory import get_factory
 from runzi.automation.toshi_api import ModelType
 from runzi.aws import get_ecs_job_config, resolve_job_definition_digest
+from runzi.aws.batch_query import batch_job_name
 from runzi.protocols import ModuleWithDefaultSubmissionArgs
 
 INITIAL_GATEWAY_PORT = 26533  # set this to ensure that concurrent scheduled tasks won't clash
@@ -75,12 +76,15 @@ def build_tasks(
         if local_config.CLUSTER_MODE is ClusterModeEnum.AWS:
             container_task = task_factory.get_container_task()
 
-            job_name = f"{job_name}-{task_count}"
+            # Encode the general_task_id into the job name so `runzi batch` can find this task's jobs
+            # via a list_jobs JOB_NAME prefix filter (issue #326). Derive from the base `job_name` each
+            # iteration — never reassign it, or the base would compound across tasks (job-1, job-1-2, …).
+            task_job_name = batch_job_name(general_task_id, job_name, task_count)
 
             yield get_ecs_job_config(
                 container_task=container_task,
                 model_type=model_type,
-                job_name=job_name,
+                job_name=task_job_name,
                 task_args=task_args,
                 task_runtime_args=task_runtime_args,
                 toshi_api_url=API_URL,

--- a/runzi/cli/batch_cli.py
+++ b/runzi/cli/batch_cli.py
@@ -1,0 +1,83 @@
+"""The `runzi batch` CLI: read-only inspection of a general task's AWS Batch jobs (issue #326).
+
+Federated Cognito users have no AWS console access, so this surfaces the job state they otherwise
+couldn't see. It is deliberately read-only (no terminate / log-fetching in this version).
+"""
+
+import datetime as dt
+from collections import Counter
+from typing import Annotated
+
+import typer
+from botocore.exceptions import ClientError
+from rich.console import Console
+from rich.table import Table
+
+from runzi.aws.batch_query import job_duration, jobs_for_general_task
+
+app = typer.Typer()
+console = Console()
+
+# Batch statuses we colour; everything else (SUBMITTED/PENDING/RUNNABLE/STARTING — i.e. still queued)
+# renders dim.
+_STATUS_STYLE = {'SUCCEEDED': 'green', 'FAILED': 'red', 'RUNNING': 'yellow'}
+
+
+def _created(summary: dict) -> str:
+    ms = summary.get('createdAt')
+    if not ms:
+        return '-'
+    return dt.datetime.fromtimestamp(ms / 1000).strftime('%Y-%m-%d %H:%M:%S')
+
+
+@app.command()
+def status(
+    general_task_id: Annotated[str, typer.Argument(help="the GENERAL_TASK_ID printed at submission")],
+):
+    """Show the AWS Batch jobs for a general task: name, id, status, duration, created time.
+
+    Caveats: AWS Batch keeps terminal (SUCCEEDED/FAILED) jobs for only ~24h, and only jobs submitted
+    after this feature shipped carry the discoverable job name — older jobs won't appear.
+    """
+    try:
+        jobs = jobs_for_general_task(general_task_id)
+    except ClientError as exc:
+        code = exc.response.get('Error', {}).get('Code', '')
+        if code in ('AccessDenied', 'AccessDeniedException'):
+            console.print(
+                "[red]Access denied calling batch:ListJobs.[/red] Your access tier lacks AWS Batch "
+                "read permissions; log in at the runzi-batch tier with `toshi-auth login`."
+            )
+            raise typer.Exit(code=1) from None
+        raise
+
+    if not jobs:
+        console.print(
+            f"[yellow]Found no Batch jobs for general task {general_task_id}.[/yellow] Terminal jobs "
+            "age out of AWS Batch after ~24h, and only jobs submitted after this feature shipped are "
+            "discoverable."
+        )
+        return
+
+    table = Table(title=f"Batch jobs for {general_task_id}")
+    for column in ("Job Name", "Job ID", "Status", "Duration", "Created"):
+        table.add_column(column)
+    for job in jobs:
+        job_status = job.get('status', 'UNKNOWN')
+        style = _STATUS_STYLE.get(job_status, 'dim')
+        table.add_row(
+            job.get('jobName', '-'),
+            job.get('jobId', '-'),
+            f"[{style}]{job_status}[/]",
+            job_duration(job),
+            _created(job),
+        )
+    console.print(table)
+
+    counts = Counter(job.get('status', 'UNKNOWN') for job in jobs)
+    breakdown = "  ".join(f"{name}: {n}" for name, n in sorted(counts.items()))
+    console.print(f"[bold]{len(jobs)} job(s)[/bold]  {breakdown}")
+
+
+if __name__ == "__main__":
+    app()

--- a/runzi/cli/runzi_cli.py
+++ b/runzi/cli/runzi_cli.py
@@ -9,6 +9,7 @@ from typer.core import TyperGroup
 from runzi.automation import local_config
 from runzi.automation.local_config import ClusterModeEnum
 from runzi.cli import (
+    batch_cli,
     docker_wrapper,
     hazard_cli,
     inversion_cli,
@@ -125,6 +126,7 @@ app.add_typer(inversion_post_process_cli.app, name="ipp", help="inversion post p
 app.add_typer(rupture_sets_cli.app, name="rupset", help="create rupture sets", no_args_is_help=True)
 app.add_typer(reports_cli.app, name="reports", help="create inversion and rupture set reports", no_args_is_help=True)
 app.add_typer(utils_cli.app, name="utils", help="utilities", no_args_is_help=True)
+app.add_typer(batch_cli.app, name="batch", help="inspect AWS Batch jobs for a general task", no_args_is_help=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -1,0 +1,66 @@
+"""Tests for the `runzi batch status` CLI (issue #326)."""
+
+import re
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+from typer.testing import CliRunner
+
+from runzi.cli import batch_cli, runzi_cli
+
+runner = CliRunner(env={"NO_COLOR": "1", "LANG": "en_US.UTF-8", "COLUMNS": "200"})
+
+GT_ID = 'R2VuZXJhbFRhc2s6MTAxMjI1'
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r'\x1b\[[0-9;]*m', '', text)
+
+
+SUMMARIES = [
+    {
+        'jobId': 'aaaa-1111',
+        'jobName': f'{GT_ID}-job-1',
+        'status': 'SUCCEEDED',
+        'createdAt': 1_000_000,
+        'startedAt': 1_010_000,
+        'stoppedAt': 1_070_000,
+    },
+    {
+        'jobId': 'bbbb-2222',
+        'jobName': f'{GT_ID}-job-2',
+        'status': 'RUNNING',
+        'createdAt': 1_005_000,
+        'startedAt': 1_015_000,
+    },
+]
+
+
+def test_status_renders_rows_and_status_counts():
+    with patch.object(batch_cli, 'jobs_for_general_task', return_value=SUMMARIES) as mock_jobs:
+        result = runner.invoke(runzi_cli.app, ['batch', 'status', GT_ID])
+
+    assert result.exit_code == 0
+    mock_jobs.assert_called_once_with(GT_ID)
+    out = strip_ansi(result.output)
+    assert 'aaaa-1111' in out
+    assert 'bbbb-2222' in out
+    assert 'SUCCEEDED' in out
+    assert 'RUNNING' in out
+
+
+def test_status_reports_when_no_jobs_found():
+    with patch.object(batch_cli, 'jobs_for_general_task', return_value=[]):
+        result = runner.invoke(runzi_cli.app, ['batch', 'status', GT_ID])
+
+    assert result.exit_code == 0
+    assert 'no' in strip_ansi(result.output).lower()
+
+
+def test_status_handles_access_denied():
+    err = ClientError({'Error': {'Code': 'AccessDeniedException', 'Message': 'not authorized'}}, 'ListJobs')
+    with patch.object(batch_cli, 'jobs_for_general_task', side_effect=err):
+        result = runner.invoke(runzi_cli.app, ['batch', 'status', GT_ID])
+
+    assert result.exit_code == 1
+    assert 'batch:ListJobs' in strip_ansi(result.output)

--- a/tests/test_batch_query.py
+++ b/tests/test_batch_query.py
@@ -1,0 +1,112 @@
+"""Tests for runzi.aws.batch_query — the read-only AWS Batch inspection primitives (issue #326)."""
+
+import re
+
+from runzi.arguments import DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE
+from runzi.aws.batch_query import (
+    batch_job_name,
+    general_task_id_token,
+    job_duration,
+    jobs_for_general_task,
+)
+
+# Batch job names must match this (letters/numbers/underscore/hyphen, start alphanumeric, <=128).
+JOB_NAME_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$')
+
+
+class TestGeneralTaskIdToken:
+    def test_is_deterministic(self):
+        gt_id = 'R2VuZXJhbFRhc2s6MTAxMjI1'
+        assert general_task_id_token(gt_id) == general_task_id_token(gt_id)
+
+    def test_real_gt_id_is_job_name_safe(self):
+        # A real toshi id (base64 of "GeneralTask:<int>") is already safe and passes through unchanged.
+        assert general_task_id_token('R2VuZXJhbFRhc2s6MTAxMjI1') == 'R2VuZXJhbFRhc2s6MTAxMjI1'
+
+    def test_maps_base64_specials_and_strips_padding(self):
+        # '+' and '/' both map to '_' (so the token contains no '-'); '=' padding is stripped.
+        assert general_task_id_token('AB+/CD==') == 'AB__CD'
+
+    def test_token_never_contains_a_hyphen(self):
+        # The '-' is reserved as the job-name delimiter, so it must never appear inside the token.
+        assert '-' not in general_task_id_token('AB+/CD==')
+
+
+class TestBatchJobName:
+    def test_encodes_token_prefix(self):
+        gt_id = 'R2VuZXJhbFRhc2s6MTAxMjI1'
+        assert batch_job_name(gt_id, 'OpenquakeHazard', 3) == f'{gt_id}-OpenquakeHazard-3'
+
+    def test_none_gt_id_falls_back_to_legacy_format(self):
+        assert batch_job_name(None, 'OpenquakeHazard', 3) == 'OpenquakeHazard-3'
+
+    def test_result_is_a_valid_batch_job_name(self):
+        assert JOB_NAME_RE.match(batch_job_name('AB+/CD==', 'OpenquakeHazard', 12))
+
+    def test_delimiter_is_unambiguous(self):
+        # token has no '-', so splitting on the first '-' recovers the token exactly.
+        name = batch_job_name('AB+/CD==', 'Base', 1)
+        assert name.split('-', 1)[0] == general_task_id_token('AB+/CD==')
+
+
+class TestJobDuration:
+    def test_completed_job_is_stopped_minus_started(self):
+        summary = {'createdAt': 0, 'startedAt': 1_000_000, 'stoppedAt': 1_000_000 + 3_661_000}
+        assert job_duration(summary) == '1:01:01'
+
+    def test_running_job_is_now_minus_started(self):
+        summary = {'createdAt': 0, 'startedAt': 10_000}
+        assert job_duration(summary, now_ms=10_000 + 62_000) == '0:01:02'
+
+    def test_not_yet_started_job_has_no_duration(self):
+        assert job_duration({'createdAt': 0}) == '-'
+
+
+class _FakeBatchClient:
+    """Records list_jobs paginate calls per queue and returns canned jobSummaryList pages."""
+
+    def __init__(self, pages_by_queue):
+        self._pages_by_queue = pages_by_queue
+        self.paginate_calls = []
+
+    def get_paginator(self, name):
+        assert name == 'list_jobs'
+        return self
+
+    def paginate(self, **kwargs):
+        self.paginate_calls.append(kwargs)
+        yield from self._pages_by_queue.get(kwargs['jobQueue'], [])
+
+
+class _FakeSession:
+    def __init__(self, client):
+        self._client = client
+
+    def client(self, service_name, **kwargs):
+        assert service_name == 'batch'
+        return self._client
+
+
+class TestJobsForGeneralTask:
+    GT_ID = 'R2VuZXJhbFRhc2s6MTAxMjI1'
+
+    def _client(self):
+        return _FakeBatchClient(
+            {
+                DEFAULT_JOB_QUEUE: [{'jobSummaryList': [{'jobId': 'a', 'createdAt': 200}]}],
+                EC2_JOB_QUEUE: [{'jobSummaryList': [{'jobId': 'b', 'createdAt': 100}]}],
+            }
+        )
+
+    def test_queries_both_queues_with_job_name_prefix_filter(self):
+        client = self._client()
+        jobs_for_general_task(self.GT_ID, session=_FakeSession(client))
+
+        queried_queues = {call['jobQueue'] for call in client.paginate_calls}
+        assert queried_queues == {DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE}
+        for call in client.paginate_calls:
+            assert call['filters'] == [{'name': 'JOB_NAME', 'values': [f'{self.GT_ID}-*']}]
+
+    def test_merges_results_sorted_by_created_at(self):
+        jobs = jobs_for_general_task(self.GT_ID, session=_FakeSession(self._client()))
+        assert [j['jobId'] for j in jobs] == ['b', 'a']  # createdAt 100 before 200

--- a/tests/test_build_tasks_job_name.py
+++ b/tests/test_build_tasks_job_name.py
@@ -1,0 +1,61 @@
+"""build_tasks must encode the general_task_id into each AWS Batch job name (issue #326), and must
+not compound the base name across tasks."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _run_build_tasks(monkeypatch, general_task_id, n_tasks):
+    from runzi import build_tasks as bt
+    from runzi.arguments import SubmissionArgs, TaskLanguage
+    from runzi.automation.local_config import ClusterModeEnum
+    from runzi.automation.toshi_api import ModelType
+
+    monkeypatch.setattr(bt.local_config, 'USE_API', True)
+    monkeypatch.setattr(bt.local_config, 'CLUSTER_MODE', ClusterModeEnum.AWS)
+
+    submission_args = SubmissionArgs(
+        task_language=TaskLanguage.PYTHON, ecs_max_job_time_min=30, ecs_memory=1024, ecs_vcpu=1
+    )
+
+    mock_sweeper = MagicMock()
+    mock_sweeper.get_tasks.return_value = [MagicMock() for _ in range(n_tasks)]
+    mock_module = MagicMock()
+    mock_module.__name__ = 'runzi.tasks.example'
+
+    fake_factory = MagicMock()
+    fake_factory.get_next_port.return_value = 26000
+    fake_factory.get_container_task.return_value = 'run.sh'
+    fake_factory_class = MagicMock()
+    fake_factory_class.create.return_value = fake_factory
+
+    job_names = []
+
+    with (
+        patch.object(bt, 'get_factory', return_value=fake_factory_class),
+        patch.object(bt, 'resolve_job_definition_digest', return_value='sha256:x'),
+        patch.object(bt, 'get_ecs_job_config', side_effect=lambda **kw: job_names.append(kw['job_name'])),
+    ):
+        list(
+            bt.build_tasks(
+                mock_sweeper,
+                submission_args,
+                mock_module,
+                ModelType.CRUSTAL,
+                'job',
+                general_task_id=general_task_id,
+            )
+        )
+    return job_names
+
+
+def test_job_name_carries_general_task_id_prefix(monkeypatch):
+    gt_id = 'R2VuZXJhbFRhc2s6MTAxMjI1'
+    job_names = _run_build_tasks(monkeypatch, gt_id, n_tasks=2)
+    assert job_names == [f'{gt_id}-job-1', f'{gt_id}-job-2']
+
+
+def test_base_name_does_not_compound_across_tasks(monkeypatch):
+    # Regression: the old `job_name = f"{job_name}-{task_count}"` reassigned the shared name, so
+    # task 2 became "job-1-2". Each task must derive independently from the base.
+    job_names = _run_build_tasks(monkeypatch, 'R2VuZXJhbFRhc2s6MTAxMjI1', n_tasks=3)
+    assert all('job-1-' not in name for name in job_names[1:])


### PR DESCRIPTION
Closes #326.

## Why
Federated Cognito users of runzi-batch have **no AWS console access**, so today they cannot see what happened to jobs they submitted. This adds a CLI to inspect them.

## What
A read-only, general-task-centric command:

```bash
runzi batch status <GENERAL_TASK_ID>
```

Lists a general task's AWS Batch jobs across both the Fargate and EC2 queues, with **status** (colour-coded), **run duration**, and **creation time**, plus a count-by-status summary.

## How it finds the jobs (a naming contract)
AWS Batch `list_jobs` can filter by queue + job-name prefix, but **not** by tags or the container config. So:

- `build_tasks` now encodes a sanitised `general_task_id` token as the **prefix** of each Batch job name (`<gt-token>-<base>-<task_count>`, see `runzi/aws/batch_query.py:batch_job_name`).
- `jobs_for_general_task` queries with a `list_jobs` `JOB_NAME` `<gt-token>-*` filter (JobSummary already carries status + timestamps, so no `describe_jobs` needed).

Future changes to job naming **must preserve this prefix**. Documented in code + `docs/usage/aws_batch.md`.

## Also fixes
A latent **compounding bug** in `build_tasks`: the shared `job_name` was reassigned inside the task loop (task 2 became `job-1-2`, task 3 `job-1-2-3`, …). Each task now derives its name independently from the base. Covered by a regression test.

## Scope / decisions
- **Read-only v1**: terminate, log-fetching, and standalone config-decode are **deferred**.
- **No IAM/Terraform change** — the `runzi_batch` access tier already grants `batch:ListJobs`/`batch:DescribeJobs` (log-fetching would later need `logs:GetLogEvents`).
- **Caveats** (surfaced in `--help`, the empty-result message, and docs): Batch retains terminal jobs only ~24h; the name encoding is forward-only, so jobs submitted before this shipped aren't discoverable.

## Testing
- New: `tests/test_batch_query.py`, `tests/test_batch_cli.py`, `tests/test_build_tasks_job_name.py`.
- `ruff check` clean, `mypy` clean (115 files), full suite **229 passed**.
- CLI smoke-tested via the real `runzi` entrypoint.

⚠️ **Not yet verified against live AWS.** The `JOB_NAME`-filter-returns-all-statuses behavior is exercised only via a mock; a real end-to-end run (submit a small job, then `runzi batch status <GT_ID>`) is recommended before relying on it.