### PR TITLE
feat(batch): route :prod JDs to prod toshi, :experimental to test (ADR-0010)

### DIFF
--- a/docs/architecture/adr/0010-batch-toshi-stage-per-image-tag.md
+++ b/docs/architecture/adr/0010-batch-toshi-stage-per-image-tag.md
@@ -1,0 +1,63 @@
+# Couple toshi stage (prod/test) to the Batch image-tag axis
+
+## Decision
+
+**The `:prod` Batch job definitions authenticate to the PROD toshi environment; the `:experimental`
+job definitions authenticate to the TEST toshi environment.** The toshi auth pair
+(`NZSHM22_TOSHI_M2M_SECRET_ARN` + `NZSHM22_TOSHI_COGNITO_DOMAIN`) is baked into each job definition's
+container `environment`, so "which toshi stage a job writes to" is now selected by *which job
+definition* a scientist runs — the same choice that already selects the image tag (`:prod` via
+`runzi utils promote`, `:experimental` via `runzi utils docker-build`).
+
+In `terraform/batch`, the single `job_definition_environment` map is split into three:
+
+| variable | consumed by | holds |
+|---|---|---|
+| `job_definition_environment` | all four JDs | stage-agnostic vars (e.g. `NZSHM22_S3_UPLOAD_WORKERS`) |
+| `prod_job_definition_environment` | `prod`, `ec2_prod` | PROD toshi secret ARN + Cognito domain |
+| `experimental_job_definition_environment` | `experimental`, `ec2_experimental` | TEST toshi secret ARN + Cognito domain |
+
+Each JD's `environment` is `merge(job_definition_environment, <stage overlay>)`, derived in a `locals`
+block (`prod_environment` / `experimental_environment`) so a stage-agnostic var cannot drift between
+the two.
+
+## Two deciding inputs
+
+1. **A container env var holds exactly one value, and runzi never injects it.** The toshi client reads
+   the fixed name `NZSHM22_TOSHI_M2M_SECRET_ARN` inside the container at runtime;
+   [0009](0009-submission-vs-runtime-args.md) made M2M auth the job definition's responsibility, and
+   `tests/test_get_ecs_job_config.py` / `tests/test_docker_wrapper.py` assert runzi never forwards it.
+   So supporting prod cannot be a runtime selection in runzi — a job definition must carry the prod
+   pair. Reusing the existing `:prod`/`:experimental` JD axis needs **zero runzi code change**: the
+   `ecs_job_definition` submission arg already selects the definition.
+
+2. **The coupling is a desired guardrail.** Binding stage to the image tag means unreviewed
+   (`:experimental`) images can only write to the test toshi environment; only a deliberately promoted
+   (`:prod`) image writes to prod. The accepted trade-off is that code-version and data-stage become
+   one axis: there is no path to run a promoted image against test, or experimental code against prod.
+   Neither is needed today; if that changes, a real stage axis (separate JDs or a workspace-
+   parameterized module like `terraform/access`) would be required instead.
+
+## Consequences / deferred obligations
+
+- **The prod secret's read grant lives outside this repo.** The container reads the secret under
+  `job_role_arn` / `execution_role_arn` = `arn:aws:iam::461564345538:role/toshi_batch_ECS_TaskExecution`,
+  which is **not** managed here (`terraform/batch/main.tf` header). That role must be granted
+  `secretsmanager:GetSecretValue` on the **prod** secret ARN (in addition to test), in whatever system
+  owns it (likely `nshm-toshi-api`), or `:prod` jobs fail auth at runtime. `terraform/access` grants no
+  secretsmanager permission ([0006](0006-runzi-access-tier-least-privilege.md)), so nothing changes there.
+- **`apply` re-registers all four job definitions** with the new per-stage `environment`. No queues or
+  compute environments change. The gitignored `terraform.tfvars` must supply the prod ARN + domain.
+
+## Files
+
+- `terraform/batch/variables.tf` — `job_definition_environment` re-described as stage-agnostic;
+  new `prod_job_definition_environment` / `experimental_job_definition_environment` (both `map(string)`,
+  default `{}`).
+- `terraform/batch/main.tf` — `locals.prod_environment` / `locals.experimental_environment`;
+  `environment` removed from the shared `base_container_properties` / `ec2_container_properties` and
+  set per-JD in the four `aws_batch_job_definition` resources.
+- `terraform/batch/terraform.tfvars` — three-map form (prod overlay = prod toshi, experimental overlay
+  = the previous test values).
+- `terraform/batch/terraform.tfvars.example` — documents the three-map shape.
+- [0007](0007-job-definition-terraform-tag-publish.md) — the `:prod`/`:experimental` tag axis this reuses.

--- a/terraform/batch/README.md
+++ b/terraform/batch/README.md
@@ -90,7 +90,12 @@ Map the `containerProperties` fields to variables:
 - `networkConfiguration.assignPublicIp` → `assign_public_ip`. If the output has **no**
   `networkConfiguration` block, set `assign_public_ip = ""` so the new definitions omit it too (AWS
   treats absent as `DISABLED`).
-- static `environment` entries → `job_definition_environment`.
+- static `environment` entries → split by toshi stage (ADR-0010): stage-agnostic vars (e.g.
+  `NZSHM22_S3_UPLOAD_WORKERS`) go in `job_definition_environment`; the toshi auth pair
+  (`NZSHM22_TOSHI_M2M_SECRET_ARN` + `NZSHM22_TOSHI_COGNITO_DOMAIN`) goes in
+  `prod_job_definition_environment` (PROD toshi, for the `:prod` JDs) and
+  `experimental_job_definition_environment` (TEST toshi, for the `:experimental` JDs). The prod secret
+  ARN must also be readable by the external `toshi_batch_ECS_TaskExecution` role (see ADR-0010).
 - `image_repository` → the ECR repo URI **without** a tag.
 
 Copy `terraform.tfvars.example` to `terraform.tfvars` and fill these in (gitignored — it's
@@ -118,7 +123,8 @@ Map:
   egress (NAT or auto-assigned public IPs).
 
 The EC2 job definitions reuse the same `image_repository`, `execution_role_arn`, `job_role_arn`,
-and `job_definition_environment` as the Fargate ones. Instance types (`ec2_instance_types`,
+and per-stage environment maps as the Fargate ones (`ec2_prod` tracks the prod toshi overlay,
+`ec2_experimental` the test one — ADR-0010). Instance types (`ec2_instance_types`,
 default `["optimal"]`), `min_vcpus` (default 0), and allocation strategy default sensibly —
 instance-type tuning is tracked in #323.
 

--- a/terraform/batch/main.tf
+++ b/terraform/batch/main.tf
@@ -39,6 +39,12 @@ resource "aws_batch_job_queue" "fargate" {
 # submit time (runzi/aws/aws.py). container_properties must replicate the live Fargate-runzi-opensha-JD
 # apart from the tagged image — discover and reconcile it before apply (README.md).
 locals {
+  # Per-stage container env (ADR-0010): the :prod definitions authenticate to prod toshi, the
+  # :experimental ones to test toshi. Each is the stage-agnostic base plus the stage's toshi overlay;
+  # deriving both from the shared base keeps a stage-agnostic var from drifting between them.
+  prod_environment         = merge(var.job_definition_environment, var.prod_job_definition_environment)
+  experimental_environment = merge(var.job_definition_environment, var.experimental_job_definition_environment)
+
   # Only emit networkConfiguration when assign_public_ip is set; an empty value omits the block
   # entirely, matching a live JD that has no networkConfiguration (AWS treats absent as DISABLED).
   # It is not overridable per-job, so the JD-level value governs at runtime — keep it faithful.
@@ -61,7 +67,7 @@ locals {
     # runzi always overrides command at submit time; a non-empty default keeps the definition valid.
     command = ["--help"]
 
-    environment                  = [for k, v in var.job_definition_environment : { name = k, value = v }]
+    # environment is set per-definition below (prod vs experimental toshi stage, ADR-0010).
     fargatePlatformConfiguration = { platformVersion = "LATEST" }
   }, local.network_configuration)
 }
@@ -72,7 +78,8 @@ resource "aws_batch_job_definition" "prod" {
   platform_capabilities = ["FARGATE"]
 
   container_properties = jsonencode(merge(local.base_container_properties, {
-    image = "${var.image_repository}:${var.prod_image_tag}"
+    image       = "${var.image_repository}:${var.prod_image_tag}"
+    environment = [for k, v in local.prod_environment : { name = k, value = v }]
   }))
 }
 
@@ -82,7 +89,8 @@ resource "aws_batch_job_definition" "experimental" {
   platform_capabilities = ["FARGATE"]
 
   container_properties = jsonencode(merge(local.base_container_properties, {
-    image = "${var.image_repository}:${var.experimental_image_tag}"
+    image       = "${var.image_repository}:${var.experimental_image_tag}"
+    environment = [for k, v in local.experimental_environment : { name = k, value = v }]
   }))
 }
 
@@ -151,7 +159,7 @@ locals {
 
     command = ["--help"]
 
-    environment = [for k, v in var.job_definition_environment : { name = k, value = v }]
+    # environment is set per-definition below (prod vs experimental toshi stage, ADR-0010).
   }
 }
 
@@ -161,7 +169,8 @@ resource "aws_batch_job_definition" "ec2_prod" {
   platform_capabilities = ["EC2"]
 
   container_properties = jsonencode(merge(local.ec2_container_properties, {
-    image = "${var.image_repository}:${var.prod_image_tag}"
+    image       = "${var.image_repository}:${var.prod_image_tag}"
+    environment = [for k, v in local.prod_environment : { name = k, value = v }]
   }))
 }
 
@@ -171,6 +180,7 @@ resource "aws_batch_job_definition" "ec2_experimental" {
   platform_capabilities = ["EC2"]
 
   container_properties = jsonencode(merge(local.ec2_container_properties, {
-    image = "${var.image_repository}:${var.experimental_image_tag}"
+    image       = "${var.image_repository}:${var.experimental_image_tag}"
+    environment = [for k, v in local.experimental_environment : { name = k, value = v }]
   }))
 }

--- a/terraform/batch/terraform.tfvars.example
+++ b/terraform/batch/terraform.tfvars.example
@@ -22,10 +22,23 @@ job_role_arn       = ""      # TODO - the live JD's jobRoleArn, or "" to omit
 default_vcpu       = "8"     # TODO - resourceRequirements VCPU entry
 default_memory     = "32768" # TODO - resourceRequirements MEMORY entry (MiB); must be valid for default_vcpu
 assign_public_ip   = ""      # TODO - networkConfiguration.assignPublicIp (ENABLED/DISABLED), or "" if absent
+# Env is split by toshi stage (ADR-0010): the :prod JDs authenticate to prod toshi, the :experimental
+# JDs to test toshi. job_definition_environment holds only stage-agnostic vars shared by all four JDs;
+# the toshi auth pair goes in the per-stage overlays below (merged over the shared base).
 job_definition_environment = {
-  # TODO - copy the live JD's static environment entries, e.g.:
-  # NZSHM22_TOSHI_M2M_SECRET_ARN = "arn:aws:secretsmanager:ap-southeast-2:TODO:secret:toshi-m2m-..."
-  # NZSHM22_TOSHI_COGNITO_DOMAIN = "https://TODO.auth.ap-southeast-2.amazoncognito.com"
+  # TODO - stage-agnostic entries from the live JD, e.g.:
+  # NZSHM22_S3_UPLOAD_WORKERS = "5"
+}
+# :prod JDs -> PROD toshi. The external toshi_batch_ECS_TaskExecution role must be granted
+# secretsmanager:GetSecretValue on this ARN, or :prod jobs fail auth at runtime.
+prod_job_definition_environment = {
+  # NZSHM22_TOSHI_M2M_SECRET_ARN = "arn:aws:secretsmanager:ap-southeast-2:TODO:secret:toshi-m2m-prod-..."
+  # NZSHM22_TOSHI_COGNITO_DOMAIN = "https://toshi-TODO-prod.auth.ap-southeast-2.amazoncognito.com"
+}
+# :experimental JDs -> TEST toshi.
+experimental_job_definition_environment = {
+  # NZSHM22_TOSHI_M2M_SECRET_ARN = "arn:aws:secretsmanager:ap-southeast-2:TODO:secret:toshi-m2m-test-..."
+  # NZSHM22_TOSHI_COGNITO_DOMAIN = "https://toshi-TODO-test.auth.ap-southeast-2.amazoncognito.com"
 }
 
 # ── EC2 compute environment, queue, and job definitions (ADR-0008, #322) ──

--- a/terraform/batch/variables.tf
+++ b/terraform/batch/variables.tf
@@ -98,8 +98,25 @@ variable "default_memory" {
   default     = "32768"
 }
 
+# Env baked into the job definitions is split across three maps so the :prod and :experimental
+# definitions can authenticate to different toshi stages (ADR-0010). job_definition_environment holds
+# stage-agnostic vars shared by all four JDs; the two stage overlays below carry the toshi auth pair
+# (NZSHM22_TOSHI_M2M_SECRET_ARN + NZSHM22_TOSHI_COGNITO_DOMAIN) and are merged over the shared base.
+# Per-job runtime env is set by runzi via containerOverrides, not here.
 variable "job_definition_environment" {
-  description = "Static environment variables baked into the job definition (e.g. NZSHM22_TOSHI_M2M_SECRET_ARN, NZSHM22_TOSHI_COGNITO_DOMAIN). Discover from the live JD; per-job runtime env is set by runzi via containerOverrides, not here."
+  description = "Stage-agnostic environment variables baked into every job definition (e.g. NZSHM22_S3_UPLOAD_WORKERS). The toshi auth pair lives in the per-stage overlays below, not here. Discover from the live JD."
+  type        = map(string)
+  default     = {}
+}
+
+variable "prod_job_definition_environment" {
+  description = "Toshi auth env for the :prod job definitions (Fargate + EC2) — the PROD NZSHM22_TOSHI_M2M_SECRET_ARN + NZSHM22_TOSHI_COGNITO_DOMAIN. Merged over job_definition_environment (ADR-0010)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "experimental_job_definition_environment" {
+  description = "Toshi auth env for the :experimental job definitions (Fargate + EC2) — the TEST NZSHM22_TOSHI_M2M_SECRET_ARN + NZSHM22_TOSHI_COGNITO_DOMAIN. Merged over job_definition_environment (ADR-0010)."
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
## What

Splits the single `job_definition_environment` map in `terraform/batch` into a stage-agnostic base plus two per-stage overlays, so the toshi auth environment is baked per job definition:

- `:prod` JDs (`runzi-fargate-JD`, `runzi-ec2-JD`) authenticate to **prod** toshi
- `:experimental` JDs authenticate to **test** toshi

The toshi auth pair (`NZSHM22_TOSHI_M2M_SECRET_ARN` + `NZSHM22_TOSHI_COGNITO_DOMAIN`) is carried by the JD; scientists already select which JD runs via `ecs_job_definition` / the experimental flag, so **no runzi code changes**.

## Why

The batch module previously baked one M2M secret (test) into every JD. A container env var holds exactly one value and the toshi client reads a fixed name at runtime (ADR-0009), so "prod as well" has to be expressed by *which JD runs*, not runtime selection. Reusing the existing `:prod`/`:experimental` image-tag axis gives a guardrail: unreviewed (`:experimental`) images can only write to test toshi; only promoted (`:prod`) images write to prod. Trade-off (accepted): code-version and data-stage become one axis.

See `docs/architecture/adr/0010-batch-toshi-stage-per-image-tag.md`.

## Deferred obligation

The external `toshi_batch_ECS_TaskExecution` role (owned outside this repo) must be granted `secretsmanager:GetSecretValue` on the **prod** secret ARN, or `:prod` jobs fail to read it. This is documented in ADR-0010.

## Changes

- `terraform/batch/variables.tf` — `job_definition_environment` re-scoped to stage-agnostic; new `prod_job_definition_environment` / `experimental_job_definition_environment`
- `terraform/batch/main.tf` — `locals.prod_environment` / `experimental_environment` (shared base + overlay); `environment` moved from the shared container-property locals into each of the four JD resources
- `terraform/batch/terraform.tfvars.example`, `README.md` — documented the three-map shape
- `docs/architecture/adr/0010-batch-toshi-stage-per-image-tag.md` — new ADR

## Verification

- `terraform validate` passes; `main.tf`/`variables.tf` fmt-clean
- The M2M-injection guard tests still pass (`tests/test_get_ecs_job_config.py`, `tests/test_docker_wrapper.py`) — runzi still never injects the secret
- Live `runzi-ec2-JD:2` confirmed carrying the prod secret ARN + prod cognito domain after apply

## Note

Applying this surfaced a separate, **prod-side** issue: the prod API Gateway authorizer (`aihssdkef5`) rejects the correctly-minted, correctly-scoped M2M token with `401 {"message":"Unauthorized"}`. That is an nshm-toshi-api prod config gap (method Authorization Scopes / authorizer pool), not addressed here — this PR's batch config is correct.