### PR TITLE
feat(batch): show swept-arg columns in `runzi batch status` (#335)

### DIFF
--- a/docs/superpowers/specs/2026-07-04-batch-status-swept-args-design.md
+++ b/docs/superpowers/specs/2026-07-04-batch-status-swept-args-design.md
@@ -1,0 +1,144 @@
+# Design: identify Batch jobs by swept argument (#335)
+
+**Status:** approved (brainstorming)
+**Date:** 2026-07-04
+**Issue:** [#335](https://github.com/GNS-Science/nzshm-runzi/issues/335) — "identify batch jobs"
+**Builds on:** [#332](https://github.com/GNS-Science/nzshm-runzi/pull/332) (read-only `runzi batch status`)
+
+## Problem
+
+`runzi batch status <GENERAL_TASK_ID>` lists a general task's AWS Batch jobs with
+status, duration, and creation time. When a general task sweeps arguments it fans out
+into many jobs that are otherwise indistinguishable in the table — the user cannot tell
+*which swept-argument combination* each job ran. This design adds that information.
+
+## Goal
+
+For each listed Batch job, show the swept-argument values that job ran with, so a
+federated Cognito user (who has no AWS console access) can identify jobs at a glance.
+
+## Approach
+
+Decode each job's **own** encoded config (the config that was shipped to that job's
+container at submit time), rather than reconstructing it from toshi or re-encoding it at
+submit time.
+
+### Why this approach
+
+Three options were considered:
+
+- **A — Reconstruct from toshi `argument_lists`.** One toshi GraphQL read of the general
+  task, then replay `itertools.product(...)` and index by `task_count`. Light, and swept
+  keys are directly known (values with length > 1). Rejected because it adds a toshi
+  dependency to an otherwise AWS-only command and is a *reconstruction* — if
+  `ArgSweeper`'s enumeration ever changes, the labels silently drift from what the jobs
+  actually ran.
+- **B — Encode swept args into the job name/tags at submit time.** Keeps the query
+  AWS-only, but is a submit-side change, is length-limited (Batch job names cap out), and
+  is forward-only (won't help already-submitted jobs). Weakest option.
+- **C — Decode each job's own encoded config (chosen).** Self-contained in AWS Batch (no
+  toshi), **authoritative** (it is literally what the job ran, not a replay), and reuses
+  existing code (`decompress_config`). `batch:DescribeJobs` is already granted to the
+  `runzi_batch` access tier (per #332).
+
+### Data flow
+
+1. `jobs_for_general_task()` returns the `JobSummary` list (status + timestamps) via the
+   existing `list_jobs` job-name-prefix filter — **unchanged**.
+2. New step: take those `jobId`s and call `describe_jobs`, batched in groups of **≤100**
+   (the AWS `describe_jobs` limit). From each job's `container.environment`, read the
+   `TASK_CONFIG_JSON_QUOTED` variable, pass it through the existing
+   `decompress_config()` (`runzi/aws/aws.py:194`), `json.loads` the result, and read the
+   `task_args` dict (the structure is produced by `get_task_config`:
+   `{task_args, task_runtime_args, model_type}`).
+3. Compute the **swept keys** by diffing `task_args` across the decoded jobs: any key
+   whose value is not identical across all decoded jobs becomes a column. Diff
+   `task_args` **only** — never `task_runtime_args` (its `java_gateway_port` varies per
+   task but is not user-facing). Sort the resulting keys alphabetically for stable output.
+
+Each job's `task_args` is the prototype with only its swept combination overridden, so the
+keys that differ across jobs are exactly the swept ones. Showing all `task_args` keys
+would produce dozens of unusable columns; showing only the varying ones is precisely the
+disambiguation the issue asks for.
+
+## Display
+
+Table columns become:
+
+```
+Job ID · Status · Duration · Created · <swept-key-1> · <swept-key-2> · …
+```
+
+- The **Job Name** column is dropped (its encoded `general_task_id` token prefix is
+  identical for every row of one general task, and the readable `task_count` tail is
+  redundant next to Job ID + swept columns).
+- One column **per swept key**, sorted alphabetically.
+- Cell value is `str(value)` of that job's swept-arg value. Long/complex values (e.g.
+  lists) render via `str()`; no truncation in v1 unless it proves ugly in practice.
+- Status colouring, duration, created, and the count-by-status summary line are unchanged.
+
+Example:
+
+```
+Job ID     Status     Duration  Created              rupture_set  deformation_model
+1a2b-...   SUCCEEDED  0:12:03   2026-07-04 09:00:01  A            geologic
+3c4d-...   RUNNING    0:03:11   2026-07-04 09:00:02  A            geodetic
+5e6f-...   FAILED     0:00:44   2026-07-04 09:00:03  B            geologic
+```
+
+## Error handling / edge cases
+
+- **`describe_jobs` AccessDenied** → same treatment as the existing `list_jobs` denial
+  path, with a message naming `batch:DescribeJobs`. (Safety net; the tier already grants
+  it.)
+- **A job whose config cannot be decoded** (missing env var, decompress/JSON error) →
+  that job's swept cells render blank; no crash. Other jobs are unaffected.
+- **Only one job survives, or no key varies** → no swept columns appear; the base table
+  (today's behaviour) is shown. One job means there is nothing to disambiguate.
+- **Retention/inference caveat** — "swept" is inferred from what varies among *visible*
+  jobs. Because Batch retains terminal jobs only ~24h, if every job of a given slice has
+  aged out, a swept key that is constant across the survivors will not get a column. This
+  is documented alongside the existing retention caveat in `--help` and
+  `docs/usage/aws_batch.md`. Authoritative labelling regardless of retention would require
+  the toshi reconstruction (option A), noted as a possible future enhancement.
+
+## Components / boundaries
+
+- **`runzi/aws/batch_query.py`** — pure, testable logic:
+  - a function that, given job IDs and a session, calls `describe_jobs` (batched ≤100),
+    extracts + decodes each job's `task_args`, and returns a `{jobId: task_args_dict}`
+    mapping (jobs that fail to decode are absent or map to `None`).
+  - a function that, given the decoded `task_args` mapping, returns the sorted list of
+    swept (varying) keys.
+- **`runzi/cli/batch_cli.py`** — presentation only: calls the query helpers, drops the Job
+  Name column, renders one column per swept key, fills per-row values (blank when a job's
+  config is missing/undecodable), and keeps the existing status colouring and summary.
+- **`docs/usage/aws_batch.md`** — document the new columns and the retention/inference
+  caveat.
+
+This preserves the existing split (logic in `batch_query`, Rich rendering in `batch_cli`)
+so the new behaviour is unit-testable without constructing a table.
+
+## Testing
+
+- **`tests/test_batch_query.py`** (extend):
+  - `describe_jobs` extraction: mock `describe_jobs` returning a `container.environment`
+    with a real `compress_config`-encoded config; assert the decoder returns the expected
+    `task_args` dict. Include a batching test (>100 job IDs → multiple `describe_jobs`
+    calls).
+  - Swept-key diffing: given several decoded `task_args` dicts, assert only the varying
+    keys are returned, sorted; assert `task_runtime_args` is never considered; assert
+    identical configs → empty list.
+  - Decode-failure path: a job with a missing/garbage env var yields no entry (or `None`)
+    rather than raising.
+- **`tests/test_batch_cli.py`** (extend):
+  - Table has a column per swept key with correct per-row values; the Job Name column is
+    gone.
+  - No-variation case → no swept columns.
+  - `describe_jobs` AccessDenied → friendly message + exit 1.
+
+## Out of scope
+
+- Terminate / log-fetching (still deferred from #332).
+- Toshi-based authoritative labelling (option A) — possible future enhancement.
+- Value truncation/formatting beyond `str()`.

--- a/docs/usage/aws_batch.md
+++ b/docs/usage/aws_batch.md
@@ -125,6 +125,11 @@ appear. The name encoding is also forward-only — jobs submitted before this fe
 discoverable. (Terminate, log-fetching, and config decode are intentionally out of scope for this
 read-only version; log-fetching would additionally require a `logs:GetLogEvents` grant.)
 
+Each swept argument (an argument whose value differs across this general task's jobs) is shown as
+its own column, decoded from each job's own shipped config. Because the swept columns are inferred
+from the jobs still visible in AWS Batch, and Batch retains terminal jobs only ~24h, a swept
+argument that happens to be constant across the surviving jobs will not appear as a column.
+
 # Infrastructure-as-code
 
 Both the **Fargate** (compute env, `BasicFargate_Q`, `runzi-fargate-*` definitions) and **EC2**

--- a/docs/usage/aws_batch.md
+++ b/docs/usage/aws_batch.md
@@ -125,10 +125,11 @@ appear. The name encoding is also forward-only — jobs submitted before this fe
 discoverable. (Terminate, log-fetching, and config decode are intentionally out of scope for this
 read-only version; log-fetching would additionally require a `logs:GetLogEvents` grant.)
 
-Each swept argument (an argument whose value differs across this general task's jobs) is shown as
-its own column, decoded from each job's own shipped config. Because the swept columns are inferred
-from the jobs still visible in AWS Batch, and Batch retains terminal jobs only ~24h, a swept
-argument that happens to be constant across the surviving jobs will not appear as a column.
+**Swept-argument columns.** Each swept argument (an argument whose value differs across this
+general task's jobs) is shown as its own column, decoded from each job's own shipped config.
+Because the swept columns are inferred from the jobs still visible in AWS Batch, and Batch retains
+terminal jobs only ~24h, a swept argument that happens to be constant across the surviving jobs
+will not appear as a column.
 
 # Infrastructure-as-code
 

--- a/runzi/aws/batch_query.py
+++ b/runzi/aws/batch_query.py
@@ -8,6 +8,7 @@ without arbitrary tags (which ``list_jobs`` cannot filter on).
 
 import json
 import time
+import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from runzi.arguments import DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE
@@ -105,8 +106,14 @@ def _decode_task_args(job: dict[str, Any]) -> dict[str, Any] | None:
     if not encoded:
         return None
     try:
-        config = json.loads(decompress_config(encoded))
+        # Mirror the worker's get_config() decode order: URL-quoted first, compressed second.
+        try:
+            config = json.loads(urllib.parse.unquote(encoded))
+        except (json.JSONDecodeError, ValueError):
+            config = json.loads(decompress_config(encoded))
     except Exception:
+        return None
+    if not isinstance(config, dict):
         return None
     return config.get('task_args')
 

--- a/runzi/aws/batch_query.py
+++ b/runzi/aws/batch_query.py
@@ -6,10 +6,12 @@ job-name prefix, so this token makes a general task's jobs discoverable without 
 without arbitrary tags (which ``list_jobs`` cannot filter on).
 """
 
+import json
 import time
 from typing import TYPE_CHECKING, Any
 
 from runzi.arguments import DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE
+from runzi.aws.aws import decompress_config
 from runzi.aws.session import get_session
 
 if TYPE_CHECKING:
@@ -87,3 +89,46 @@ def jobs_for_general_task(
             jobs.extend(page.get('jobSummaryList', []))
     jobs.sort(key=lambda job: job.get('createdAt', 0))
     return jobs
+
+
+_DESCRIBE_JOBS_BATCH = 100  # AWS describe_jobs accepts at most 100 job ids per call.
+
+
+def _decode_task_args(job: dict[str, Any]) -> dict[str, Any] | None:
+    """Decode a job's shipped ``task_args`` from its ``TASK_CONFIG_JSON_QUOTED`` container env var.
+
+    Returns ``None`` if the variable is absent or cannot be decompressed/parsed (e.g. a legacy job),
+    so the caller can render a blank rather than crashing the whole table for one bad job.
+    """
+    environment = job.get('container', {}).get('environment', [])
+    encoded = next((e.get('value') for e in environment if e.get('name') == 'TASK_CONFIG_JSON_QUOTED'), None)
+    if not encoded:
+        return None
+    try:
+        config = json.loads(decompress_config(encoded))
+    except Exception:
+        return None
+    return config.get('task_args')
+
+
+def task_args_by_job_id(
+    job_ids: list[str],
+    session: 'boto3.Session | None' = None,
+) -> dict[str, dict[str, Any]]:
+    """Return ``{job_id: task_args}`` by decoding each job's own shipped config (issue #335).
+
+    Each Batch job carries the exact config it ran in ``TASK_CONFIG_JSON_QUOTED``; this reads it back
+    with ``describe_jobs`` (batched in groups of 100, the AWS limit) rather than reconstructing it.
+    Jobs whose config is missing or undecodable are omitted from the mapping.
+    """
+    client = (session or get_session()).client(
+        service_name='batch', region_name=_BATCH_REGION, endpoint_url=_BATCH_ENDPOINT
+    )
+    result: dict[str, dict[str, Any]] = {}
+    for start in range(0, len(job_ids), _DESCRIBE_JOBS_BATCH):
+        chunk = job_ids[start : start + _DESCRIBE_JOBS_BATCH]
+        for job in client.describe_jobs(jobs=chunk).get('jobs', []):
+            task_args = _decode_task_args(job)
+            if task_args is not None:
+                result[job['jobId']] = task_args
+    return result

--- a/runzi/aws/batch_query.py
+++ b/runzi/aws/batch_query.py
@@ -132,3 +132,22 @@ def task_args_by_job_id(
             if task_args is not None:
                 result[job['jobId']] = task_args
     return result
+
+
+def swept_arg_keys(task_args_by_job: dict[str, dict[str, Any]]) -> list[str]:
+    """Return the sorted ``task_args`` keys whose value differs across jobs — i.e. the swept ones.
+
+    Each job's ``task_args`` is the prototype with only its swept combination overridden, so the keys
+    that vary across jobs are exactly the swept ones. Values are compared via a canonical JSON form so
+    list/dict-valued args compare correctly. Fewer than two decoded jobs means nothing to disambiguate.
+    """
+    configs = list(task_args_by_job.values())
+    if len(configs) < 2:
+        return []
+    all_keys: set[str] = set().union(*(config.keys() for config in configs))
+    varying = [
+        key
+        for key in all_keys
+        if len({json.dumps(config.get(key), sort_keys=True, default=str) for config in configs}) > 1
+    ]
+    return sorted(varying)

--- a/runzi/cli/batch_cli.py
+++ b/runzi/cli/batch_cli.py
@@ -13,7 +13,7 @@ from botocore.exceptions import ClientError
 from rich.console import Console
 from rich.table import Table
 
-from runzi.aws.batch_query import job_duration, jobs_for_general_task
+from runzi.aws.batch_query import job_duration, jobs_for_general_task, swept_arg_keys, task_args_by_job_id
 
 app = typer.Typer()
 console = Console()
@@ -30,25 +30,33 @@ def _created(summary: dict) -> str:
     return dt.datetime.fromtimestamp(ms / 1000).strftime('%Y-%m-%d %H:%M:%S')
 
 
+def _exit_on_access_denied(exc: ClientError, permission: str) -> None:
+    """Print a friendly message and exit(1) if `exc` is an access-denied error; otherwise return."""
+    code = exc.response.get('Error', {}).get('Code', '')
+    if code in ('AccessDenied', 'AccessDeniedException'):
+        console.print(
+            f"[red]Access denied calling {permission}.[/red] Your access tier lacks AWS Batch "
+            "read permissions; log in at the runzi-batch tier with `toshi-auth login`."
+        )
+        raise typer.Exit(code=1) from None
+
+
 @app.command()
 def status(
     general_task_id: Annotated[str, typer.Argument(help="the GENERAL_TASK_ID printed at submission")],
 ):
-    """Show the AWS Batch jobs for a general task: name, id, status, duration, created time.
+    """Show the AWS Batch jobs for a general task: id, status, duration, created time, swept args.
 
-    Caveats: AWS Batch keeps terminal (SUCCEEDED/FAILED) jobs for only ~24h, and only jobs submitted
-    after this feature shipped carry the discoverable job name — older jobs won't appear.
+    A column is added per swept argument (the args whose values differ across this task's jobs),
+    read from each job's own shipped config. Caveats: AWS Batch keeps terminal (SUCCEEDED/FAILED)
+    jobs for only ~24h, and only jobs submitted after this feature shipped carry the discoverable job
+    name — older jobs won't appear. Because swept columns are inferred from what varies among the
+    jobs still visible, a swept arg that is constant across the survivors won't get a column.
     """
     try:
         jobs = jobs_for_general_task(general_task_id)
     except ClientError as exc:
-        code = exc.response.get('Error', {}).get('Code', '')
-        if code in ('AccessDenied', 'AccessDeniedException'):
-            console.print(
-                "[red]Access denied calling batch:ListJobs.[/red] Your access tier lacks AWS Batch "
-                "read permissions; log in at the runzi-batch tier with `toshi-auth login`."
-            )
-            raise typer.Exit(code=1) from None
+        _exit_on_access_denied(exc, 'batch:ListJobs')
         raise
 
     if not jobs:
@@ -59,18 +67,28 @@ def status(
         )
         return
 
+    try:
+        task_args_by_job = task_args_by_job_id([job['jobId'] for job in jobs])
+    except ClientError as exc:
+        _exit_on_access_denied(exc, 'batch:DescribeJobs')
+        raise
+
+    swept_keys = swept_arg_keys(task_args_by_job)
+
     table = Table(title=f"Batch jobs for {general_task_id}")
-    for column in ("Job Name", "Job ID", "Status", "Duration", "Created"):
+    for column in ("Job ID", "Status", "Duration", "Created", *swept_keys):
         table.add_column(column)
     for job in jobs:
         job_status = job.get('status', 'UNKNOWN')
         style = _STATUS_STYLE.get(job_status, 'dim')
+        args = task_args_by_job.get(job.get('jobId', ''), {})
+        swept_cells = [str(args.get(key, '')) for key in swept_keys]
         table.add_row(
-            job.get('jobName', '-'),
             job.get('jobId', '-'),
             f"[{style}]{job_status}[/]",
             job_duration(job),
             _created(job),
+            *swept_cells,
         )
     console.print(table)
 

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -37,7 +37,9 @@ SUMMARIES = [
 
 
 def test_status_renders_rows_and_status_counts():
-    with patch.object(batch_cli, 'jobs_for_general_task', return_value=SUMMARIES) as mock_jobs:
+    with patch.object(batch_cli, 'jobs_for_general_task', return_value=SUMMARIES) as mock_jobs, patch.object(
+        batch_cli, 'task_args_by_job_id', return_value={}
+    ):
         result = runner.invoke(runzi_cli.app, ['batch', 'status', GT_ID])
 
     assert result.exit_code == 0
@@ -64,3 +66,48 @@ def test_status_handles_access_denied():
 
     assert result.exit_code == 1
     assert 'batch:ListJobs' in strip_ansi(result.output)
+
+
+def test_status_shows_a_column_per_swept_key():
+    task_args = {
+        'aaaa-1111': {'rupture_set': 'A', 'deformation_model': 'geologic'},
+        'bbbb-2222': {'rupture_set': 'B', 'deformation_model': 'geologic'},
+    }
+    with patch.object(batch_cli, 'jobs_for_general_task', return_value=SUMMARIES), patch.object(
+        batch_cli, 'task_args_by_job_id', return_value=task_args
+    ):
+        result = runner.invoke(runzi_cli.app, ['batch', 'status', GT_ID])
+
+    assert result.exit_code == 0
+    out = strip_ansi(result.output)
+    assert 'rupture_set' in out  # swept -> a column
+    assert 'deformation_model' not in out  # constant -> no column
+    assert 'Job Name' not in out  # dropped
+    # each job's swept value is on its row
+    assert re.search(r'aaaa-1111.*\bA\b', out)
+    assert re.search(r'bbbb-2222.*\bB\b', out)
+
+
+def test_status_has_no_swept_columns_when_nothing_varies():
+    task_args = {
+        'aaaa-1111': {'rupture_set': 'A'},
+        'bbbb-2222': {'rupture_set': 'A'},
+    }
+    with patch.object(batch_cli, 'jobs_for_general_task', return_value=SUMMARIES), patch.object(
+        batch_cli, 'task_args_by_job_id', return_value=task_args
+    ):
+        result = runner.invoke(runzi_cli.app, ['batch', 'status', GT_ID])
+
+    assert result.exit_code == 0
+    assert 'rupture_set' not in strip_ansi(result.output)
+
+
+def test_status_handles_describe_access_denied():
+    err = ClientError({'Error': {'Code': 'AccessDeniedException', 'Message': 'not authorized'}}, 'DescribeJobs')
+    with patch.object(batch_cli, 'jobs_for_general_task', return_value=SUMMARIES), patch.object(
+        batch_cli, 'task_args_by_job_id', side_effect=err
+    ):
+        result = runner.invoke(runzi_cli.app, ['batch', 'status', GT_ID])
+
+    assert result.exit_code == 1
+    assert 'batch:DescribeJobs' in strip_ansi(result.output)

--- a/tests/test_batch_query.py
+++ b/tests/test_batch_query.py
@@ -10,6 +10,7 @@ from runzi.aws.batch_query import (
     general_task_id_token,
     job_duration,
     jobs_for_general_task,
+    swept_arg_keys,
     task_args_by_job_id,
 )
 
@@ -173,3 +174,28 @@ class TestTaskArgsByJobId:
         )
         result = task_args_by_job_id(['a', 'b', 'c'], session=_FakeSession(client))
         assert result == {'a': {'rupture_set': 'A'}}
+
+
+class TestSweptArgKeys:
+    def test_returns_only_varying_keys_sorted(self):
+        by_job = {
+            'a': {'rupture_set': 'A', 'deformation_model': 'geologic', 'model_id': 'X'},
+            'b': {'rupture_set': 'A', 'deformation_model': 'geodetic', 'model_id': 'X'},
+            'c': {'rupture_set': 'B', 'deformation_model': 'geologic', 'model_id': 'X'},
+        }
+        assert swept_arg_keys(by_job) == ['deformation_model', 'rupture_set']
+
+    def test_identical_configs_yield_no_keys(self):
+        by_job = {'a': {'rupture_set': 'A'}, 'b': {'rupture_set': 'A'}}
+        assert swept_arg_keys(by_job) == []
+
+    def test_fewer_than_two_jobs_yields_no_keys(self):
+        assert swept_arg_keys({'a': {'rupture_set': 'A'}}) == []
+        assert swept_arg_keys({}) == []
+
+    def test_handles_list_valued_args(self):
+        by_job = {
+            'a': {'vs30s': [200, 300], 'rupture_set': 'A'},
+            'b': {'vs30s': [400, 500], 'rupture_set': 'A'},
+        }
+        assert swept_arg_keys(by_job) == ['vs30s']

--- a/tests/test_batch_query.py
+++ b/tests/test_batch_query.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import urllib.parse
 
 from runzi.arguments import DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE
 from runzi.aws.aws import compress_config
@@ -129,6 +130,20 @@ def _job_with_config(job_id, task_args):
     }
 
 
+def _job_with_quoted_config(job_id, task_args):
+    """Build a fake job whose TASK_CONFIG_JSON_QUOTED was written with the URL-quoted (non-compressed) form."""
+    config = {
+        'task_args': task_args,
+        'task_runtime_args': {'task_count': 1, 'java_gateway_port': 26533},
+        'model_type': 10,
+    }
+    encoded = urllib.parse.quote(json.dumps(config))
+    return {
+        'jobId': job_id,
+        'container': {'environment': [{'name': 'TASK_CONFIG_JSON_QUOTED', 'value': encoded}]},
+    }
+
+
 class _FakeDescribeClient:
     """Records describe_jobs calls and returns canned job detail by id."""
 
@@ -175,6 +190,20 @@ class TestTaskArgsByJobId:
         result = task_args_by_job_id(['a', 'b', 'c'], session=_FakeSession(client))
         assert result == {'a': {'rupture_set': 'A'}}
 
+    def test_decodes_url_quoted_config(self):
+        """Jobs written with the URL-quoted (non-compressed) form also decode correctly."""
+        client = _FakeDescribeClient(
+            {
+                'a': _job_with_quoted_config('a', {'rupture_set': 'A', 'model_id': 'X'}),
+                'b': _job_with_quoted_config('b', {'rupture_set': 'B', 'model_id': 'X'}),
+            }
+        )
+        result = task_args_by_job_id(['a', 'b'], session=_FakeSession(client))
+        assert result == {
+            'a': {'rupture_set': 'A', 'model_id': 'X'},
+            'b': {'rupture_set': 'B', 'model_id': 'X'},
+        }
+
 
 class TestSweptArgKeys:
     def test_returns_only_varying_keys_sorted(self):
@@ -199,3 +228,10 @@ class TestSweptArgKeys:
             'b': {'vs30s': [400, 500], 'rupture_set': 'A'},
         }
         assert swept_arg_keys(by_job) == ['vs30s']
+
+    def test_handles_dict_valued_args(self):
+        by_job = {
+            'a': {'site_params': {'vs30': 200, 'z1pt0': 0.5}},
+            'b': {'site_params': {'vs30': 400, 'z1pt0': 0.5}},
+        }
+        assert swept_arg_keys(by_job) == ['site_params']

--- a/tests/test_batch_query.py
+++ b/tests/test_batch_query.py
@@ -1,13 +1,16 @@
 """Tests for runzi.aws.batch_query — the read-only AWS Batch inspection primitives (issue #326)."""
 
+import json
 import re
 
 from runzi.arguments import DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE
+from runzi.aws.aws import compress_config
 from runzi.aws.batch_query import (
     batch_job_name,
     general_task_id_token,
     job_duration,
     jobs_for_general_task,
+    task_args_by_job_id,
 )
 
 # Batch job names must match this (letters/numbers/underscore/hyphen, start alphanumeric, <=128).
@@ -110,3 +113,63 @@ class TestJobsForGeneralTask:
     def test_merges_results_sorted_by_created_at(self):
         jobs = jobs_for_general_task(self.GT_ID, session=_FakeSession(self._client()))
         assert [j['jobId'] for j in jobs] == ['b', 'a']  # createdAt 100 before 200
+
+
+def _job_with_config(job_id, task_args):
+    config = {
+        'task_args': task_args,
+        'task_runtime_args': {'task_count': 1, 'java_gateway_port': 26533},
+        'model_type': 10,
+    }
+    encoded = compress_config(json.dumps(config))
+    return {
+        'jobId': job_id,
+        'container': {'environment': [{'name': 'TASK_CONFIG_JSON_QUOTED', 'value': encoded}]},
+    }
+
+
+class _FakeDescribeClient:
+    """Records describe_jobs calls and returns canned job detail by id."""
+
+    def __init__(self, jobs_by_id):
+        self._jobs_by_id = jobs_by_id
+        self.describe_calls = []
+
+    def describe_jobs(self, jobs):
+        self.describe_calls.append(list(jobs))
+        return {'jobs': [self._jobs_by_id[j] for j in jobs if j in self._jobs_by_id]}
+
+
+class TestTaskArgsByJobId:
+    def test_decodes_task_args_for_each_job(self):
+        client = _FakeDescribeClient(
+            {
+                'a': _job_with_config('a', {'rupture_set': 'A', 'model_id': 'X'}),
+                'b': _job_with_config('b', {'rupture_set': 'B', 'model_id': 'X'}),
+            }
+        )
+        result = task_args_by_job_id(['a', 'b'], session=_FakeSession(client))
+        assert result == {
+            'a': {'rupture_set': 'A', 'model_id': 'X'},
+            'b': {'rupture_set': 'B', 'model_id': 'X'},
+        }
+
+    def test_batches_describe_jobs_in_chunks_of_100(self):
+        ids = [str(n) for n in range(150)]
+        client = _FakeDescribeClient({i: _job_with_config(i, {'k': i}) for i in ids})
+        task_args_by_job_id(ids, session=_FakeSession(client))
+        assert [len(call) for call in client.describe_calls] == [100, 50]
+
+    def test_omits_jobs_with_no_decodable_config(self):
+        client = _FakeDescribeClient(
+            {
+                'a': _job_with_config('a', {'rupture_set': 'A'}),
+                'b': {'jobId': 'b', 'container': {'environment': []}},  # no TASK_CONFIG_JSON_QUOTED
+                'c': {
+                    'jobId': 'c',
+                    'container': {'environment': [{'name': 'TASK_CONFIG_JSON_QUOTED', 'value': 'garbage'}]},
+                },
+            }
+        )
+        result = task_args_by_job_id(['a', 'b', 'c'], session=_FakeSession(client))
+        assert result == {'a': {'rupture_set': 'A'}}


### PR DESCRIPTION
Closes #335.

Follows up on #332 (read-only `runzi batch status`): the status table now shows **which swept argument each Batch job ran with**, so federated Cognito users (no AWS console access) can tell a general task's fanned-out jobs apart.

## What

```
Job ID     Status     Duration  Created              rupture_set  deformation_model
1a2b-...   SUCCEEDED  0:12:03   2026-07-06 09:00:01  A            geologic
3c4d-...   RUNNING    0:03:11   2026-07-06 09:00:02  A            geodetic
5e6f-...   FAILED     0:00:44   2026-07-06 09:00:03  B            geologic
```

- One column **per swept argument** (the args whose values differ across this task's jobs), sorted alphabetically.
- The **Job Name** column is dropped (its `general_task_id` token prefix was identical on every row and redundant next to Job ID).

## How (approach C — decode each job's own config)

Each Batch job already ships its exact config in the `TASK_CONFIG_JSON_QUOTED` container env var. So:

1. `jobs_for_general_task()` discovers the jobs via the existing `list_jobs` name-prefix filter (unchanged).
2. `task_args_by_job_id()` calls `describe_jobs` (batched ≤100), reads `TASK_CONFIG_JSON_QUOTED`, decodes it (URL-quoted or `decompress_config`, mirroring the worker's `get_config()`), and returns `{jobId: task_args}`. Jobs with a missing/undecodable config are omitted → rendered as blank cells.
3. `swept_arg_keys()` diffs `task_args` across jobs; the keys that vary are exactly the swept ones. `task_runtime_args` is never diffed.

This keeps the command **AWS-only** (no toshi dependency) and **authoritative** — it shows what each job actually ran, not a reconstruction. `batch:DescribeJobs` is already granted to the `runzi_batch` access tier (per #332). Rationale and alternatives (toshi reconstruction, submit-side encoding) are in `docs/superpowers/specs/2026-07-04-batch-status-swept-args-design.md`.

## Caveats (documented in `--help` + `docs/usage/aws_batch.md`)

Swept columns are inferred from what varies among *visible* jobs. Because Batch retains terminal jobs only ~24h, a swept arg that is constant across the survivors won't get a column.

## Testing

- New/updated: `tests/test_batch_query.py` (decode + batching + diff, incl. dict-valued and URL-quoted cases), `tests/test_batch_cli.py` (per-key columns, no-variation, `batch:DescribeJobs` denial, Job Name gone).
- Full suite **241 passed**, `ruff check` clean, `mypy` clean (115 files).

⚠️ **Not yet verified against live AWS** — the `describe_jobs` decode path is exercised only via mocks. A real `runzi batch status <GT_ID>` after a small swept submission is recommended before relying on it.
