### PR TITLE
fix(batch): give each EC2 job a unique py4j gateway port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ The core execution pipeline is:
 
 ### Key Abstractions
 
-**`SubmissionArgs` / `TaskRuntimeArgs`** (`runzi/arguments.py`): the submission↔worker arg split (ADR-0009). `SubmissionArgs` is the submitter-only config (ECS sizing, job definition, queue/compute env, task language) that each task module declares as a module-level `default_submission_args` instance and is **not** serialized to the worker. `TaskRuntimeArgs` is the small per-task context the worker needs (`general_task_id`, `task_count`, `use_api`, `java_gateway_port`, `java_threads`); it's assembled in `build_tasks` and is the only args model shipped to the container.
+**`SubmissionArgs` / `TaskRuntimeArgs`** (`runzi/arguments.py`): the submission↔worker arg split (ADR-0009). `SubmissionArgs` is the submitter-only config (ECS sizing, job definition, queue/compute env, task language) that each task module declares as a module-level `default_submission_args` instance and is **not** serialized to the worker. `TaskRuntimeArgs` is the small per-task context the worker needs (`general_task_id`, `task_count`, `use_api`, `java_threads`); it's assembled in `build_tasks` and is the only args model shipped to the container. Its `java_gateway_port` is a compute-on-read property (not a shipped field): the launcher that starts the JVM exports `NZSHM22_APP_PORT` (a free port per container on AWS Batch, where forced host networking makes a fixed port collide across concurrent jobs; the per-task port in the generated bash script on LOCAL/CLUSTER) and the property reads it, keeping the JVM and Python client on one port.
 
 **Task-specific `*Args`** classes: Pydantic models for user-provided job parameters (e.g., `OQHazardArgs` in `runzi/tasks/oq_hazard/hazard_args.py`).
 

--- a/docker/java_container_task.sh
+++ b/docker/java_container_task.sh
@@ -2,7 +2,14 @@
 
 export JAVA_CLASSPATH=${NZSHM22_FATJAR}
 export CLASSNAME=nz.cri.gns.NZSHM22.opensha.util.NZSHM22_PythonGateway
-export NZSHM22_APP_PORT=26533
+
+# AWS Batch forces host networking on EC2, so every job container on an instance shares
+# 127.0.0.1. A fixed gateway port makes concurrent jobs collide: the first JVM wins the port,
+# the rest fail to bind, and their Python clients connect to the winner's JVM instead —
+# corrupting results and writing solutions to the wrong container's filesystem. Pick a free
+# ephemeral port per container at runtime; get_config() forwards NZSHM22_APP_PORT to the Python
+# client so both ends of the py4j gateway agree on the same port.
+export NZSHM22_APP_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
 
 /opt/java/bin/java -Xms4G -Xmx${NZSHM22_SCRIPT_JVM_HEAP_MAX}G -XX:ActiveProcessorCount=${NZSHM22_AWS_JAVA_THREADS} -classpath ${JAVA_CLASSPATH} ${CLASSNAME} > ${NZSHM22_SCRIPT_WORK_PATH}/java_app.${NZSHM22_APP_PORT}.log &
 

--- a/runzi/arguments.py
+++ b/runzi/arguments.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import os
 from collections.abc import Generator, Sequence
 from enum import Enum
 from pathlib import Path
@@ -128,8 +129,24 @@ class TaskRuntimeArgs(BaseModel):
     general_task_id: str | None = None
     task_count: int = 0
     use_api: bool
-    java_gateway_port: int | None = None
     java_threads: int | None = None
+
+    @property
+    def java_gateway_port(self) -> int:
+        """The py4j gateway port, read from NZSHM22_APP_PORT at runtime.
+
+        The port belongs to the JVM process, not the submitter: whichever launcher starts the
+        gateway exports NZSHM22_APP_PORT (a free port per container on AWS Batch, where forced host
+        networking makes a fixed port collide across concurrent jobs; the per-task port in the
+        generated bash script on LOCAL/CLUSTER). Reading it here — rather than shipping it in the
+        config — keeps the JVM and the Python client on the same port with a single source of truth.
+        """
+        port = os.environ.get('NZSHM22_APP_PORT')
+        if port is None:
+            raise RuntimeError(
+                "NZSHM22_APP_PORT is not set; the task launcher must export it before the JVM gateway starts"
+            )
+        return int(port)
 
 
 class ArgSweeper:

--- a/runzi/automation/opensha_task_factory.py
+++ b/runzi/automation/opensha_task_factory.py
@@ -47,8 +47,6 @@ class TaskFactory(Protocol):
 
     def get_task_script(self) -> str: ...
 
-    def get_next_port(self) -> int: ...
-
     @classmethod
     def create(cls, **kwargs) -> "TaskFactory": ...
 
@@ -111,9 +109,6 @@ class OpenshaTaskFactory:
 
     def get_task_script(self) -> str:
         return self._get_bash_script()
-
-    def get_next_port(self) -> int:
-        return self._next_port
 
     def _get_bash_script(self) -> str:
         """

--- a/runzi/automation/opensha_task_factory.py
+++ b/runzi/automation/opensha_task_factory.py
@@ -60,15 +60,13 @@ class OpenshaTaskFactory:
         jre_path: Path | PurePath | str,
         app_jar_path: Path | PurePath | str,
         task_config_path: Path | PurePath | str | None = None,
-        initial_gateway_port: int = 25333,
         python: str = "python3",
         jvm_heap_start: int = 3,
         jvm_heap_max: int = 10,
     ):
-        """
-        initial_gateway_port: what port to start incrementing from
-        """
-        self._next_port = initial_gateway_port
+        # Per-task index used only for config/log filenames; the gateway port is chosen at runtime by
+        # the generated bash script (a free port, like the AWS container script), not seeded here.
+        self._next_task = 1
 
         self._jre_path = jre_path
         self._app_jar_path = app_jar_path
@@ -93,7 +91,6 @@ class OpenshaTaskFactory:
             jre_path=kwargs["jre_path"],
             app_jar_path=kwargs["app_jar_path"],
             task_config_path=kwargs.get("task_config_path"),
-            initial_gateway_port=kwargs.get("initial_gateway_port", 25333),
             python=kwargs.get("python", "python3"),
             jvm_heap_start=kwargs.get("jvm_heap_start", 3),
             jvm_heap_max=kwargs.get("jvm_heap_max", 10),
@@ -103,7 +100,7 @@ class OpenshaTaskFactory:
         return ""
 
     def write_task_config(self, task_args: BaseModel, task_runtime_args: TaskRuntimeArgs, model_type: ModelType):
-        fname = self._config_path / f"config.{self._next_port}.json"
+        fname = self._config_path / f"config.{self._next_task}.json"
         task_config = get_task_config(task_args, task_runtime_args, model_type)
         fname.write_text(json.dumps(task_config, indent=4), encoding="utf-8")
 
@@ -115,20 +112,25 @@ class OpenshaTaskFactory:
         get the bash for the next task
         """
 
+        # Pick a free gateway port at runtime (same approach as docker/java_container_task.sh) and
+        # export it for both the JVM and the Python client. The java log is named by the runtime port
+        # so inversion_solution_builder can upload java_app.<port>.log; config/logs otherwise use the
+        # per-task index.
         script = (
             f"export PATH={self._jre_path}:$PATH\n"
             f"export JAVA_CLASSPATH={self._app_jar_path}\n"
             "export CLASSNAME=nz.cri.gns.NZSHM22.opensha.util.NZSHM22_PythonGateway\n"
-            f"export NZSHM22_APP_PORT={self._next_port}\n"
+            'export NZSHM22_APP_PORT=$(python3 -c \'import socket; s=socket.socket(); '
+            's.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()\')\n'
             f"java -Xms{self._jvm_heap_start_gb}G -Xmx{self._jvm_heap_max_gb}G"
             f" -classpath ${{JAVA_CLASSPATH}} ${{CLASSNAME}} > "
-            f"{self._working_path}/java_app.{self._next_port}.log &\n"
-            f"{self._python} {self._python_script} {self._config_path}/config.{self._next_port}.json > "
-            f"{self._working_path}/python_script.{self._next_port}.log\n"
+            f"{self._working_path}/java_app.${{NZSHM22_APP_PORT}}.log &\n"
+            f"{self._python} {self._python_script} {self._config_path}/config.{self._next_task}.json > "
+            f"{self._working_path}/python_script.{self._next_task}.log\n"
             # Kill the Java gateway server
             "kill -9 $!"
         )
-        self._next_port += 1
+        self._next_task += 1
         return script
 
 
@@ -178,7 +180,7 @@ class OpenshaPBSTaskFactory(OpenshaTaskFactory):
         return ""
 
     def write_task_config(self, task_args: BaseModel, task_runtime_args: TaskRuntimeArgs, model_type: ModelType):
-        fname = self._config_path / f"config.{self._next_port}.json"
+        fname = self._config_path / f"config.{self._next_task}.json"
         # PBS mode is unsupported; _pbs_wall_hours / _pbs_ppn keep their __init__ defaults (job timing
         # is submission-only and no longer on the per-task runtime args).
         self._pbs_ppn = task_runtime_args.java_threads or self._pbs_ppn

--- a/runzi/automation/python_task_factory.py
+++ b/runzi/automation/python_task_factory.py
@@ -51,9 +51,6 @@ class PythonTaskFactory:
     def get_container_task(self) -> str:
         return ""
 
-    def get_next_port(self) -> int:
-        return self._next_task
-
     def write_task_config(self, task_arguments: BaseModel, task_runtime_args: TaskRuntimeArgs, model_type: ModelType):
         fname = self._config_path / f"config.{self._next_task}.json"
         task_config = get_task_config(task_arguments, task_runtime_args, model_type)

--- a/runzi/build_tasks.py
+++ b/runzi/build_tasks.py
@@ -26,13 +26,6 @@ from runzi.aws import get_ecs_job_config, resolve_job_definition_digest
 from runzi.aws.batch_query import batch_job_name
 from runzi.protocols import ModuleWithDefaultSubmissionArgs
 
-# Base for the LOCAL/CLUSTER per-task index used as the py4j gateway port and the config/log file
-# suffix; the generated bash script increments it per task so co-located tasks get distinct ports and
-# filenames. AWS Batch doesn't use it: the gateway port is chosen at runtime by java_container_task.sh
-# (a free port per container, since forced host networking makes a fixed port collide across concurrent
-# jobs) and read back via TaskRuntimeArgs.java_gateway_port (NZSHM22_APP_PORT).
-INITIAL_GATEWAY_PORT = 26533
-
 
 def build_tasks(
     user_args: ArgSweeper,
@@ -52,7 +45,6 @@ def build_tasks(
         root_path=OPENSHA_ROOT,
         working_path=WORK_PATH,
         python_script_module=task_module,
-        initial_gateway_port=INITIAL_GATEWAY_PORT,
         jre_path=OPENSHA_JRE,
         app_jar_path=FATJAR,
         task_config_path=WORK_PATH,

--- a/runzi/build_tasks.py
+++ b/runzi/build_tasks.py
@@ -26,7 +26,12 @@ from runzi.aws import get_ecs_job_config, resolve_job_definition_digest
 from runzi.aws.batch_query import batch_job_name
 from runzi.protocols import ModuleWithDefaultSubmissionArgs
 
-INITIAL_GATEWAY_PORT = 26533  # set this to ensure that concurrent scheduled tasks won't clash
+# Base for the LOCAL/CLUSTER per-task index used as the py4j gateway port and the config/log file
+# suffix; the generated bash script increments it per task so co-located tasks get distinct ports and
+# filenames. AWS Batch doesn't use it: the gateway port is chosen at runtime by java_container_task.sh
+# (a free port per container, since forced host networking makes a fixed port collide across concurrent
+# jobs) and read back via TaskRuntimeArgs.java_gateway_port (NZSHM22_APP_PORT).
+INITIAL_GATEWAY_PORT = 26533
 
 
 def build_tasks(
@@ -69,7 +74,6 @@ def build_tasks(
             general_task_id=general_task_id,
             use_api=local_config.USE_API,
             task_count=task_count,
-            java_gateway_port=task_factory.get_next_port(),
             java_threads=submission_args.java_threads,
         )
 

--- a/terraform/batch/.gitignore
+++ b/terraform/batch/.gitignore
@@ -2,4 +2,4 @@
 *.tfstate
 *.tfstate.*
 terraform.tfvars
-
+tfplan

--- a/tests/test_batch_query.py
+++ b/tests/test_batch_query.py
@@ -125,7 +125,7 @@ class TestJobsForGeneralTask:
 def _job_with_config(job_id, task_args):
     config = {
         'task_args': task_args,
-        'task_runtime_args': {'task_count': 1, 'java_gateway_port': 26533},
+        'task_runtime_args': {'task_count': 1},
         'model_type': 10,
     }
     encoded = compress_config(json.dumps(config))
@@ -139,7 +139,7 @@ def _job_with_quoted_config(job_id, task_args):
     """Build a fake job whose TASK_CONFIG_JSON_QUOTED was written with the URL-quoted (non-compressed) form."""
     config = {
         'task_args': task_args,
-        'task_runtime_args': {'task_count': 1, 'java_gateway_port': 26533},
+        'task_runtime_args': {'task_count': 1},
         'model_type': 10,
     }
     encoded = urllib.parse.quote(json.dumps(config))

--- a/tests/test_build_tasks_job_name.py
+++ b/tests/test_build_tasks_job_name.py
@@ -23,7 +23,6 @@ def _run_build_tasks(monkeypatch, general_task_id, n_tasks):
     mock_module.__name__ = 'runzi.tasks.example'
 
     fake_factory = MagicMock()
-    fake_factory.get_next_port.return_value = 26000
     fake_factory.get_container_task.return_value = 'run.sh'
     fake_factory_class = MagicMock()
     fake_factory_class.create.return_value = fake_factory

--- a/tests/test_cli_cluster_mode.py
+++ b/tests/test_cli_cluster_mode.py
@@ -94,7 +94,6 @@ def test_build_tasks_uses_runtime_use_api(monkeypatch):
     mock_module.__name__ = 'runzi.tasks.example'
 
     fake_factory = MagicMock()
-    fake_factory.get_next_port.return_value = 26000
     fake_factory.get_container_task.return_value = 'run.sh'
     fake_factory_class = MagicMock()
     fake_factory_class.create.return_value = fake_factory

--- a/tests/test_get_ecs_job_config.py
+++ b/tests/test_get_ecs_job_config.py
@@ -382,7 +382,7 @@ class TestSubmissionArgsNotShipped:
 
     def test_submission_args_has_no_runtime_fields(self):
         fields = set(SubmissionArgs.model_fields)
-        assert {'general_task_id', 'task_count', 'use_api', 'java_gateway_port'} & fields == set()
+        assert {'general_task_id', 'task_count', 'use_api'} & fields == set()
 
     def test_runtime_args_has_no_submission_fields(self):
         fields = set(TaskRuntimeArgs.model_fields)
@@ -405,9 +405,7 @@ class TestTaskRuntimeArgsSerialization:
 
     def test_round_trips_through_worker_serialization(self):
         """Reproduces the worker path: model_dump(mode='json') then TaskRuntimeArgs(**dumped)."""
-        args = TaskRuntimeArgs(
-            general_task_id='GT-1', task_count=3, use_api=True, java_gateway_port=26000, java_threads=16
-        )
+        args = TaskRuntimeArgs(general_task_id='GT-1', task_count=3, use_api=True, java_threads=16)
         rebuilt = TaskRuntimeArgs(**args.model_dump(mode='json'))
         assert rebuilt == args
 
@@ -415,4 +413,4 @@ class TestTaskRuntimeArgsSerialization:
         dumped = TaskRuntimeArgs(use_api=True).model_dump(mode='json')
         assert 'ecs_job_queue' not in dumped
         assert 'ecs_compute_environment' not in dumped
-        assert set(dumped) == {'general_task_id', 'task_count', 'use_api', 'java_gateway_port', 'java_threads'}
+        assert set(dumped) == {'general_task_id', 'task_count', 'use_api', 'java_threads'}

--- a/tests/test_opensha_task_factory.py
+++ b/tests/test_opensha_task_factory.py
@@ -1,0 +1,50 @@
+"""Tests for OpenshaTaskFactory bash-script generation.
+
+After the gateway-port refactor the LOCAL/CLUSTER launcher picks a free port at runtime (like the AWS
+container script) and exports NZSHM22_APP_PORT; the per-task index is used only for config/log
+filenames (matching the sibling PythonTaskFactory). The java log filename must stay keyed to the
+runtime port because inversion_solution_builder uploads that file by name.
+"""
+
+import subprocess
+
+import runzi.build_tasks as a_module
+from runzi.automation.opensha_task_factory import OpenshaTaskFactory
+
+
+def _factory(tmp_path):
+    return OpenshaTaskFactory.create(
+        root_path=tmp_path,
+        working_path=tmp_path,
+        python_script_module=a_module,
+        jre_path='/opt/java/bin',
+        app_jar_path='/opt/app.jar',
+        task_config_path=tmp_path,
+    )
+
+
+def test_bash_script_picks_free_port_at_runtime(tmp_path):
+    script = _factory(tmp_path).get_task_script()
+    assert 'export NZSHM22_APP_PORT=$(' in script  # runtime command substitution, not a fixed port
+    assert 's.getsockname()[1]' in script
+
+
+def test_java_log_filename_follows_runtime_port(tmp_path):
+    """The uploader looks for java_app.<port>.log by the runtime port, so the launcher must write it
+    under that same runtime port, not the build-time task index."""
+    script = _factory(tmp_path).get_task_script()
+    assert 'java_app.${NZSHM22_APP_PORT}.log' in script
+
+
+def test_config_filename_uses_task_index_starting_at_one(tmp_path):
+    factory = _factory(tmp_path)
+    first = factory.get_task_script()
+    second = factory.get_task_script()
+    assert 'config.1.json' in first
+    assert 'config.2.json' in second
+
+
+def test_generated_script_is_valid_bash(tmp_path):
+    script = _factory(tmp_path).get_task_script()
+    proc = subprocess.run(['bash', '-n'], input=script, text=True, capture_output=True)
+    assert proc.returncode == 0, proc.stderr

--- a/tests/test_opensha_task_factory.py
+++ b/tests/test_opensha_task_factory.py
@@ -7,6 +7,9 @@ runtime port because inversion_solution_builder uploads that file by name.
 """
 
 import subprocess
+import sys
+
+import pytest
 
 import runzi.build_tasks as a_module
 from runzi.automation.opensha_task_factory import OpenshaTaskFactory
@@ -44,6 +47,11 @@ def test_config_filename_uses_task_index_starting_at_one(tmp_path):
     assert 'config.2.json' in second
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32',
+    reason="generated script targets unix launchers (LOCAL/CLUSTER) and the linux AWS container; "
+    "Windows has no real bash (the `bash` shim is the WSL installer stub)",
+)
 def test_generated_script_is_valid_bash(tmp_path):
     script = _factory(tmp_path).get_task_script()
     proc = subprocess.run(['bash', '-n'], input=script, text=True, capture_output=True)

--- a/tests/test_task_runtime_args.py
+++ b/tests/test_task_runtime_args.py
@@ -1,0 +1,33 @@
+"""Tests for TaskRuntimeArgs.java_gateway_port.
+
+The py4j gateway port is a runtime property of the JVM process, owned by whichever launcher starts
+it: on AWS Batch (forced host networking) java_container_task.sh picks a free port per container; on
+LOCAL/CLUSTER the generated bash script exports its per-task port. Both export NZSHM22_APP_PORT, and
+TaskRuntimeArgs reads it — so the port is never shipped through the config, and there is one runtime
+source of truth shared by the JVM and the Python client.
+"""
+
+import pytest
+
+from runzi.arguments import TaskRuntimeArgs
+
+
+def test_java_gateway_port_reads_app_port_env(monkeypatch):
+    monkeypatch.setenv('NZSHM22_APP_PORT', '51234')
+    args = TaskRuntimeArgs(use_api=True)
+    assert args.java_gateway_port == 51234
+
+
+def test_java_gateway_port_not_serialized(monkeypatch):
+    """The port is derived at runtime, so it must not appear in the config the submitter ships."""
+    monkeypatch.setenv('NZSHM22_APP_PORT', '51234')
+    args = TaskRuntimeArgs(use_api=True)
+    assert 'java_gateway_port' not in args.model_dump()
+
+
+def test_java_gateway_port_errors_when_env_unset(monkeypatch):
+    """Reading the port without a launcher having exported it is a misconfiguration, not a default."""
+    monkeypatch.delenv('NZSHM22_APP_PORT', raising=False)
+    args = TaskRuntimeArgs(use_api=True)
+    with pytest.raises(RuntimeError):
+        _ = args.java_gateway_port


### PR DESCRIPTION
## Problem

Erratic AWS Batch inversion failures: the same general task spawns many jobs, some succeed and others fail *differently* — `zip END header not found`, `FileNotFoundError` on the output solution, or truncated runs — and every job logs `java.net.BindException: Address already in use` at the top.

## Root cause

AWS Batch forces **host networking** on EC2 (the job definition reports `networkMode: null`, which Batch translates to host mode when it generates the ECS task def; see [containers-roadmap#2332](https://github.com/aws/containers-roadmap/issues/2332)). So all job containers on one instance share `127.0.0.1`, while keeping isolated filesystems.

Every task shipped the same hard-coded py4j gateway port **26533** (`docker/java_container_task.sh`), and `get_next_port()` never incremented in AWS mode — so concurrent tasks collided:

- The first JVM binds `26533`; the rest fail (`Address already in use`, which leaks to stderr → CloudWatch).
- Every task's Python client connects to `127.0.0.1:26533` — the **one winning JVM**.
- Concurrent inversions on that shared JVM corrupt each other (`zip END header not found`); solutions are written to the winner's filesystem, so losers get `FileNotFoundError`; the winner succeeds. Erratic by construction.

The `FileNotFoundError`-after-a-successful-inversion is the decisive clue: Python and the JVM it drove are on different filesystems but the same `127.0.0.1`.

## Fix

Make the gateway port a **runtime property of the JVM process**, owned by whichever launcher starts it — not build-time config. A build-time counter is insufficient here because it resets per submission, and concurrent submissions from different scientists share an instance under host networking.

- `TaskRuntimeArgs.java_gateway_port` is now a compute-on-read `@property` reading `NZSHM22_APP_PORT` (raises if unset); no longer a shipped field. Gateway clients are unchanged (still read `runtime_args.java_gateway_port`).
- `java_container_task.sh` picks a free ephemeral port per container and exports `NZSHM22_APP_PORT` for both the JVM and the Python client — no collisions regardless of how many jobs share an instance.
- LOCAL/CLUSTER already export `NZSHM22_APP_PORT` per task in the generated bash script (each task is its own `bash` process, so no env clobbering). The dead `get_next_port()` plumbing is removed.

Single runtime source of truth (the launcher's env var); no mode-switching conditional.

## Tests

- New `tests/test_task_runtime_args.py` covers the property (reads env, not serialized, errors when unset), written test-first.
- Full suite: **254 passed**; `ruff` and `mypy` clean.

## Not yet verified end-to-end

This is unit-verified but needs a **rebuilt image** (the container script is baked in) plus a **concurrent multi-task EC2 run** confirming no `Address already in use` and no cross-container `FileNotFoundError`.