### PR TITLE
fix(batch): failed Java jobs report FAILED instead of SUCCEEDED (#333)

### DIFF
--- a/demo/fail_demo.json
+++ b/demo/fail_demo.json
@@ -1,0 +1,5 @@
+{
+    "title": "Batch fail-signal test (issue #333)",
+    "description": "Intentional-failure diagnostic task; the AWS Batch job should end FAILED, not SUCCEEDED.",
+    "exit_code": 1
+}

--- a/docker/java_container_task.sh
+++ b/docker/java_container_task.sh
@@ -15,8 +15,12 @@ export NZSHM22_APP_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind((
 
 # TODO: we can do away with PYTHON_PREP_MODULE
 python3 -m ${PYTHON_TASK_MODULE} ${TASK_CONFIG_JSON_QUOTED} > ${NZSHM22_SCRIPT_WORK_PATH}/python_script.${NZSHM22_APP_PORT}.log
+status=$?
 
 #Kill the Java gateway server
-kill -9 $!
+kill -9 $! 2>/dev/null
+
+#Exit with the python task's status so AWS Batch sees failures (issue #333)
+exit $status
 
 #END_OF_SCRIPT

--- a/runzi/automation/opensha_task_factory.py
+++ b/runzi/automation/opensha_task_factory.py
@@ -127,8 +127,11 @@ class OpenshaTaskFactory:
             f"{self._working_path}/java_app.${{NZSHM22_APP_PORT}}.log &\n"
             f"{self._python} {self._python_script} {self._config_path}/config.{self._next_task}.json > "
             f"{self._working_path}/python_script.{self._next_task}.log\n"
+            "status=$?\n"
             # Kill the Java gateway server
-            "kill -9 $!"
+            "kill -9 $! 2>/dev/null\n"
+            # Propagate the python task's exit status so callers see failures (issue #333)
+            "exit $status"
         )
         self._next_task += 1
         return script

--- a/runzi/cli/utils_cli.py
+++ b/runzi/cli/utils_cli.py
@@ -6,13 +6,25 @@ from typing import Annotated
 import typer
 from rich import print as rich_print
 
+from runzi.arguments import ArgSweeper
 from runzi.cli.build_and_deploy_container import build_and_deploy_container, promote
+from runzi.tasks.faildemo import FailDemoArgs, FailDemoJobRunner
 from runzi.tasks.utils import VALID_ROW, build_manual_index, run_save_file_archive
 
 app = typer.Typer()
 
 app.command("docker-build")(build_and_deploy_container)
 app.command("promote")(promote)
+
+
+@app.command("fail-demo")
+def fail_demo(input_filepath: Path):
+    """Submit a task that intentionally exits non-zero, to verify AWS Batch reports FAILED (issue #333)."""
+    rich_print("[yellow]Submitting intentional-failure task (expect the Batch job to end FAILED).")
+    job_input = ArgSweeper.from_config_file(input_filepath, FailDemoArgs)
+    runner = FailDemoJobRunner(job_input)
+    gt_id = runner.run_jobs()
+    rich_print(f"General Task ID: [bold green]{gt_id}")
 
 
 @app.command()

--- a/runzi/tasks/faildemo/__init__.py
+++ b/runzi/tasks/faildemo/__init__.py
@@ -1,0 +1,4 @@
+from .fail_demo_runner import FailDemoJobRunner
+from .fail_demo_task import FailDemoArgs
+
+__all__ = ["FailDemoArgs", "FailDemoJobRunner"]

--- a/runzi/tasks/faildemo/fail_demo_runner.py
+++ b/runzi/tasks/faildemo/fail_demo_runner.py
@@ -1,0 +1,27 @@
+"""Runner for the intentional-failure diagnostic task (issue #333)."""
+
+import runzi.tasks.faildemo.fail_demo_task as task_module
+from runzi.arguments import ArgSweeper
+from runzi.automation.toshi_api import ModelType, SubtaskType
+from runzi.job_runner import JobRunner
+
+
+class FailDemoJobRunner(JobRunner):
+    """Submit a task that deliberately exits non-zero, to verify Batch failure signalling."""
+
+    job_name = "Runzi-automation-fail-demo"
+    # Reuse an existing toshi subtask_type: the API rejects unknown values, and this diagnostic
+    # is a throwaway anyway (typically run with the API disabled). INVERSION is a harmless label.
+    subtask_type = SubtaskType.INVERSION
+
+    def __init__(self, job_args: ArgSweeper):
+        """Initialize the FailDemoJobRunner.
+
+        Args:
+            job_args: input arguments for the jobs including swept args.
+        """
+        super().__init__(job_args, task_module)  # type: ignore
+
+    def get_model_type(self) -> ModelType:
+        # Arbitrary; only used to tag the general task when the toshi API is enabled.
+        return ModelType.CRUSTAL

--- a/runzi/tasks/faildemo/fail_demo_task.py
+++ b/runzi/tasks/faildemo/fail_demo_task.py
@@ -1,0 +1,41 @@
+"""A deliberately-failing diagnostic task.
+
+Its only job is to exit with a non-zero status so we can confirm end-to-end that AWS Batch reports
+FAILED (not SUCCEEDED) for a failed job — the regression guarded by issue #333.
+
+It is declared as a ``TaskLanguage.JAVA`` task on purpose: the exit-code masking bug lived only in the
+Java container launcher (``docker/java_container_task.sh``), so the demo must route through that path
+(via ``OpenshaAWSTaskFactory``) to be a meaningful real-world test. The JVM gateway starting or not is
+irrelevant — only the python exit status matters.
+"""
+
+import sys
+
+from pydantic import BaseModel
+
+from runzi.arguments import SubmissionArgs, TaskLanguage
+from runzi.tasks.get_config import get_config
+
+default_submission_args = SubmissionArgs(
+    task_language=TaskLanguage.JAVA,
+    ecs_max_job_time_min=5,
+    ecs_memory=2048,
+    ecs_vcpu=1,
+)
+
+
+class FailDemoArgs(BaseModel):
+    """Input for the intentional-failure diagnostic task."""
+
+    exit_code: int = 1
+    """Non-zero status the task exits with (AWS Batch should surface this as FAILED)."""
+
+    message: str = "intentional failure for issue #333 batch-fail-signal test"
+    """Marker line printed before exiting, to make the job's logs unambiguous."""
+
+
+if __name__ == "__main__":
+    config = get_config()
+    user_args = FailDemoArgs(**config.get('task_args', {}))
+    print(f"[fail-demo] {user_args.message}; exiting {user_args.exit_code}", flush=True)
+    sys.exit(user_args.exit_code)

--- a/tests/test_java_container_task_script.py
+++ b/tests/test_java_container_task_script.py
@@ -1,0 +1,61 @@
+"""Regression tests for the AWS Batch Java container entrypoint (issue #333).
+
+`docker/java_container_task.sh` launches the JVM gateway in the background, runs the python task,
+then kills the JVM. If `kill -9 $!` is the script's last command the container always exits 0 (kill
+succeeds), so AWS Batch marks failed jobs SUCCEEDED. These tests lock in that the script instead
+captures the python task's exit status and re-raises it.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'docker' / 'java_container_task.sh'
+
+
+def _script_text() -> str:
+    return SCRIPT.read_text(encoding='utf-8')
+
+
+def test_script_captures_and_reexports_python_status():
+    text = _script_text()
+    assert 'status=$?' in text
+    assert 'exit $status' in text
+    # the exit must come after the kill, so the JVM is still torn down before we return
+    assert text.index('kill -9 $!') < text.index('exit $status')
+    # and the kill must not be the last executable statement
+    assert not text.rstrip().endswith('kill -9 $!')
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32',
+    reason="linux AWS container script; Windows has no real bash (the `bash` shim is the WSL stub)",
+)
+def test_script_is_valid_bash():
+    proc = subprocess.run(['bash', '-n', str(SCRIPT)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32',
+    reason="exercises real bash exit-status semantics; Windows has no real bash",
+)
+def test_script_exit_status_is_the_python_status(tmp_path):
+    """Drive the script with stubbed java/python/kill: a failing task must yield the task's exit code."""
+    # Stubs replace the real launchers; env vars satisfy the paths the script references.
+    env_setup = (
+        'python3() { return 7; }\n'
+        'java() { :; }\n'
+        'kill() { return 0; }\n'
+        f'export NZSHM22_SCRIPT_WORK_PATH={tmp_path}\n'
+        'export NZSHM22_FATJAR=/nonexistent.jar\n'
+        'export NZSHM22_SCRIPT_JVM_HEAP_MAX=1\n'
+        'export NZSHM22_AWS_JAVA_THREADS=1\n'
+        'export PYTHON_TASK_MODULE=does.not.matter\n'
+        'export TASK_CONFIG_JSON_QUOTED=x\n'
+    )
+    harness = env_setup + _script_text()
+    proc = subprocess.run(['bash', '-c', harness], capture_output=True, text=True)
+    assert proc.returncode == 7, proc.stderr

--- a/tests/test_opensha_task_factory.py
+++ b/tests/test_opensha_task_factory.py
@@ -47,6 +47,20 @@ def test_config_filename_uses_task_index_starting_at_one(tmp_path):
     assert 'config.2.json' in second
 
 
+def test_generated_script_propagates_python_exit_status(tmp_path):
+    """The launcher must exit with the python task's status, not the trailing kill's (issue #333).
+
+    A bare `kill -9 $!` as the final command would always exit 0 (kill succeeds), masking task
+    failures from the LOCAL/CLUSTER caller (`check_call(['bash', script])`)."""
+    script = _factory(tmp_path).get_task_script()
+    # capture python's status right after its invocation, before the kill can clobber $?
+    assert 'python_script.1.log\nstatus=$?\n' in script
+    # the JVM kill must not be the last command...
+    assert not script.rstrip().endswith('kill -9 $!')
+    # ...instead the script ends by re-raising the captured status
+    assert script.rstrip().endswith('exit $status')
+
+
 @pytest.mark.skipif(
     sys.platform == 'win32',
     reason="generated script targets unix launchers (LOCAL/CLUSTER) and the linux AWS container; "
@@ -56,3 +70,17 @@ def test_generated_script_is_valid_bash(tmp_path):
     script = _factory(tmp_path).get_task_script()
     proc = subprocess.run(['bash', '-n'], input=script, text=True, capture_output=True)
     assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.skipif(
+    sys.platform == 'win32',
+    reason="exercises real bash exit-status semantics; Windows has no real bash",
+)
+def test_generated_script_exit_status_is_the_python_status(tmp_path):
+    """Functionally confirm a failing task yields a non-zero script exit (would be 0 before the fix)."""
+    script = _factory(tmp_path).get_task_script()
+    # Stub out the real launchers so we can drive exit semantics without java/python: a failing task
+    # (python3 -> exit 7) followed by a successful kill must leave the script exiting 7, not 0.
+    harness = 'python3() { return 7; }\njava() { :; }\nkill() { return 0; }\n' + script
+    proc = subprocess.run(['bash', '-c', harness], capture_output=True, text=True)
+    assert proc.returncode == 7, proc.stderr


### PR DESCRIPTION
## Problem

Fixes #333. AWS Batch jobs that fail still reported status `SUCCEEDED`, hiding real failures. Example: job `34780772-f64c-4844-8546-cd127269fb26` died with a `Py4JJavaError` / `zip END header not found` (corrupt rupture-set zip) yet Batch marked it SUCCEEDED.

## Root cause

The Java container launcher (`docker/java_container_task.sh`) and its LOCAL/CLUSTER twin (`OpenshaTaskFactory._get_bash_script`) ended in a bare `kill -9 $!`:

```
java ... &                       # JVM gateway, backgrounded
python3 -m ${MODULE} ...          # the actual task
kill -9 $!                        # <-- LAST statement
```

A shell script's exit status is that of its **last** command. `kill -9 $!` succeeds (returns 0), so the script always exited 0 — discarding the python task's non-zero exit. AWS Batch read that 0 → SUCCEEDED. Only the **Java** path was affected; the python path (`python_container_task.sh`) already runs python last.

## Fix

Capture the python task's exit status, kill the JVM silently, then re-raise it:

```
python3 -m ${MODULE} ...
status=$?
kill -9 $! 2>/dev/null
exit $status
```

Applied to both launchers for consistency (LOCAL/CLUSTER's `check_call(['bash', script])` was silently swallowing failures identically).

## Verification aid

Adds a deterministic intentional-failure diagnostic: `runzi utils fail-demo demo/fail_demo.json`. It's a `TaskLanguage.JAVA` task on purpose so it routes through the fixed `java_container_task.sh` path. Run with the toshi API disabled and confirm the Batch job ends **FAILED**. Its runner reuses `SubtaskType.INVERSION` (the toshi API rejects unknown subtask_type values).

## Tests

- `tests/test_opensha_task_factory.py` — content + functional (real bash, failing task → non-zero exit) checks.
- `tests/test_java_container_task_script.py` — new regression test for the container entrypoint.
- Local run: 20 passed; ruff + mypy clean.

## Deploy note

`java_container_task.sh` is `COPY`'d into the image at build time, so the Docker image must be rebuilt/redeployed for the fix to reach running containers.

https://claude.ai/code/session_01Jcq9otxx7SoYxP5GN2KcES