### PR TITLE
EC2 sizing benchmark for coulomb rupture-set builder + re-sized defaults

### DIFF
--- a/docs/architecture/adr/0011-ec2-compute-optimized-for-inversions.md
+++ b/docs/architecture/adr/0011-ec2-compute-optimized-for-inversions.md
@@ -1,5 +1,15 @@
 # EC2 compute target: compute-optimized (AMD-preferred) families for inversions, not `"optimal"`
 
+> **Update (2026-07-09):** the deferred *target* switch (see "Followups" below) has since been made.
+> Crustal and subduction inversions now **default to the EC2 job definition** (`runzi-ec2-JD`), not
+> Fargate, and their module sizing was refined to **8 vCPU / 14000 MiB** (down from 16384) so the job
+> fits compute-optimized `c*.2xlarge` after the ECS agent/OS reservation instead of being bumped to
+> general-purpose `m*.2xlarge`. This was prompted by the coulomb rupture-set benchmark
+> (`docs/benchmarks/ec2-sizing-coulomb-rupture-set.md`), which confirmed these Java builds are
+> compute-bound and cheapest on c-family EC2. The EC2-vs-Fargate throughput baseline named below was
+> *not* run; the switch rests on the family/sizing evidence plus EC2's lower per-vCPU price. So the
+> "Fargate remains the default" statements below now hold only for the non-inversion tasks.
+
 ## Decision
 
 **Replace the EC2 compute environment's `instance_type = ["optimal"]` with a compute-optimized-
@@ -73,10 +83,12 @@ ranking above. `"optimal"` resolves to current-gen families (it picked `r6i`/`m6
 
 ## Followups not blocking this decision
 
-- **EC2 vs Fargate baseline** — benchmark Fargate at 8 vCPU against `c6a` EC2 to decide whether
-  inversions' default *target* (currently Fargate) should change. The *sizing* half has been applied —
-  the crustal/subduction module-default `SubmissionArgs` are now 8 vCPU / 16384 MB (2:1) — but the
-  *target* stays Fargate pending this baseline.
+- **EC2 vs Fargate baseline** — ~~benchmark Fargate at 8 vCPU against `c6a` EC2 to decide whether
+  inversions' default *target* (currently Fargate) should change.~~ **Resolved 2026-07-09 (see Update
+  at top):** the target was switched to EC2 without a Fargate baseline, on the strength of the
+  rupture-set benchmark and EC2's lower per-vCPU price; sizing refined to 8 vCPU / 14000 MiB to fit
+  compute-optimized `c*.2xlarge`. A dedicated EC2-vs-Fargate throughput comparison is still worth doing
+  if the cost of inversions ever comes under scrutiny.
 - **Durable instance-type capture** — have the container read its instance type from IMDS and log it to
   `java_app.<port>.log`, so provenance survives scale-down (parsed from Toshi like iterations/energy)
   and cost no longer needs the ECS/EC2 lookup or its IAM.

--- a/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
+++ b/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
@@ -98,6 +98,7 @@ if the workload changes materially.
 
 ## Out of scope
 
-Steering the shared compute environment off `"optimal"` (so it stops defaulting to r-family) or pinning
-Graviton/Spot is a deployer/terraform change, a follow-up only if the code-side default proves
-insufficient. Instance-type *pinning* here was only to keep the benchmark's family axis clean.
+Pinning Graviton (arm64) or Spot capacity for these builds is a deployer/terraform change on the shared
+CE — a follow-up only if the code-side default proves insufficient. (The CE is already off `"optimal"` and
+excludes r-family, per ADR-0011, so that steering is done.) The per-family instance *pinning* in this
+benchmark was throwaway, only to keep the family axis clean — not a production CE change.

--- a/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
+++ b/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
@@ -86,11 +86,14 @@ The coulomb and subduction builder `default_submission_args` were re-sized accor
 |-------|----:|----:|-----|
 | `ecs_vcpu` | 4 | 4 | cheapest $/build (unchanged) |
 | `java_threads` | 16 | 4 | track vCPU; 16-on-4 oversubscribed |
-| `ecs_memory` (MiB) | 30720 | 8192 | ~2 GB/vCPU; build is low-memory; avoids r-family on `"optimal"` |
+| `ecs_memory` (MiB) | 30720 | 7000 | fits under the 8 GiB compute-optimized `c*.xlarge` ceiling (with ECS agent/OS headroom) so `BEST_FIT_PROGRESSIVE` places the job on cheap c-family, not the 16 GiB general-purpose `m*.xlarge`; heap ≈ 5 GB is ample |
 | `ecs_max_job_time_min` | 60 | 90 | the 4-vCPU build takes ~62 min — the old limit killed it |
 
-Subduction is assumed equivalent to coulomb (not independently benchmarked). Larger fault models or
-higher `max_sections` may shift the absolute times; re-run the matrix if the workload changes materially.
+The CE pool is `["c6a", "m6a", "c6i", "m6i"]` (ADR-0011, r-family excluded); at 2 GB/vCPU a c-instance is
+8 GiB, so requesting the *full* 8192 MiB would overflow the ECS-reserved headroom and force the job onto a
+16 GiB m-instance — hence 7000. Subduction is assumed equivalent to coulomb (not independently
+benchmarked). Larger fault models or higher `max_sections` may shift the absolute times; re-run the matrix
+if the workload changes materially.
 
 ## Out of scope
 

--- a/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
+++ b/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
@@ -11,7 +11,7 @@ finish, and where do extra cores stop paying?*
   `max_sections` 2000). Template: `scripts/ec2_sizing/coulomb_rupture_set.template.json`.
 - **Matrix:** instance family {`c6a`, `m6a`} × vCPU {4, 8, 16, 32, 64} × 2 replicates = 20 jobs. Families
   are **pinned** via per-family Batch queues (`terraform/ec2-sizing-benchmark/`), so the vCPU cost curve
-  isn't polluted by Batch `"optimal"` picking different families per cell. **`java_threads` is pinned to
+  isn't polluted by Batch's allocation strategy picking different families per cell. **`java_threads` is pinned to
   `ecs_vcpu`** per cell (the builder calls `setNumThreads(java_threads)`), so each cell uses every core it
   pays for and the wall-time-vs-cores curve is meaningful. Memory was sized to ~fill each family's per-vCPU
   RAM (c ≈ 1.8, m ≈ 3.8 GB/vCPU).

--- a/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
+++ b/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
@@ -88,6 +88,7 @@ The coulomb and subduction builder `default_submission_args` were re-sized accor
 | `java_threads` | 16 | 4 | track vCPU; 16-on-4 oversubscribed |
 | `ecs_memory` (MiB) | 30720 | 7000 | fits under the 8 GiB compute-optimized `c*.xlarge` ceiling (with ECS agent/OS headroom) so `BEST_FIT_PROGRESSIVE` places the job on cheap c-family, not the 16 GiB general-purpose `m*.xlarge`; heap ≈ 5 GB is ample |
 | `ecs_max_job_time_min` | 60 | 90 | the 4-vCPU build takes ~62 min — the old limit killed it |
+| `ecs_job_definition` | `runzi-fargate-JD` (default) | `runzi-ec2-JD` | these Java builds always run on the EC2 CE; 7000 MiB / 4 vCPU is below Fargate's 8192 MiB floor anyway, so the Fargate default would have failed validation |
 
 The CE pool is `["c6a", "m6a", "c6i", "m6i"]` (ADR-0011, r-family excluded); at 2 GB/vCPU a c-instance is
 8 GiB, so requesting the *full* 8192 MiB would overflow the ECS-reserved headroom and force the job onto a

--- a/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
+++ b/docs/benchmarks/ec2-sizing-coulomb-rupture-set.md
@@ -1,0 +1,99 @@
+# EC2 job-sizing benchmark — coulomb rupture-set builder
+
+Sibling of [the crustal-inversion benchmark](ec2-sizing-crustal-inversion.md) (#323), for the coulomb
+rupture-set builder (`runzi rupset coulomb`). The builder runs **to completion** (unlike the time-bounded
+inversion), so the metric is **wall-clock time**, and the question is *how fast / how cheaply does a build
+finish, and where do extra cores stop paying?*
+
+## Method
+
+- **Workload:** `INPUT_FILES/coulomb_rupture_sets_1_TEST.json` (fault model `CFM_1_0A_DOM_SANSTVZ`,
+  `max_sections` 2000). Template: `scripts/ec2_sizing/coulomb_rupture_set.template.json`.
+- **Matrix:** instance family {`c6a`, `m6a`} × vCPU {4, 8, 16, 32, 64} × 2 replicates = 20 jobs. Families
+  are **pinned** via per-family Batch queues (`terraform/ec2-sizing-benchmark/`), so the vCPU cost curve
+  isn't polluted by Batch `"optimal"` picking different families per cell. **`java_threads` is pinned to
+  `ecs_vcpu`** per cell (the builder calls `setNumThreads(java_threads)`), so each cell uses every core it
+  pays for and the wall-time-vs-cores curve is meaningful. Memory was sized to ~fill each family's per-vCPU
+  RAM (c ≈ 1.8, m ≈ 3.8 GB/vCPU).
+- **Cost** is analytical fair-share, `(instance $/hr ÷ instance vCPU) × job vCPU × wall-hours` — the cost
+  a job would carry on a fully-packed production instance. Because $/hr scales linearly with size, the
+  per-vCPU rate is constant within a family (every c6a size = $0.03825/vCPU-hr, every m6a = $0.0432), so
+  the cost is exact regardless of the size Batch actually launched.
+- Tooling: `scripts/ec2_sizing/submit_coulomb_matrix.py` + `collect_coulomb_results.py` (see the
+  `scripts/ec2_sizing/README.md` coulomb section to reproduce).
+
+## Results
+
+Mean of 2 replicates per cell:
+
+| family | vCPU | instance      | mean wall | mean $/build |
+|--------|-----:|---------------|----------:|-------------:|
+| c6a    |    4 | c6a.xlarge    |   3_740 s |      $0.1590 |
+| c6a    |    8 | c6a.2xlarge   |   2_753 s |      $0.2340 |
+| c6a    |   16 | c6a.4xlarge   |   1_956 s |      $0.3325 |
+| c6a    |   32 | c6a.8xlarge   |   1_241 s |      $0.4221 |
+| c6a    |   64 | c6a.16xlarge  |     939 s |      $0.6384 |
+| m6a    |    4 | m6a.xlarge    |   3_859 s |      $0.1852 |
+| m6a    |    8 | m6a.2xlarge   |   2_723 s |      $0.2614 |
+| m6a    |   16 | m6a.4xlarge   |   2_153 s |      $0.4133 |
+| m6a    |   32 | m6a.8xlarge   |   1_326 s |      $0.5091 |
+| m6a    |   64 | m6a.16xlarge  |     786 s |      $0.6034 |
+
+## Findings
+
+**1. Compute-bound and low-memory — as suspected.** c6a and m6a post near-identical wall times at every
+size, and **no cell OOM'd** even at c-family's ~1.8 GB/vCPU. The build does not need the memory the old
+default handed it (30 GB at 4 vCPU = 7.5 GB/vCPU), which on the shared `"optimal"` CE would have steered
+it onto expensive memory-optimized **r-family** (the same trap #323 found).
+
+**2. Parallelizes sub-linearly — the knee is at 32 vCPU.** Speedup vs 4 vCPU (c6a): 8→1.36×, 16→1.91×,
+32→3.01×, 64→3.98× (16× the cores for ~4× the speed). The marginal cost of buying speed, per doubling:
+
+| step (c6a) | time saved | extra $ | $ per minute saved |
+|------------|-----------:|--------:|-------------------:|
+| 4 → 8      |   16.5 min |  +0.075 |             0.0045 |
+| 8 → 16     |   13.3 min |  +0.099 |             0.0074 |
+| 16 → 32    |   11.9 min |  +0.090 |             0.0076 |
+| **32 → 64**|  **5.0 min**| **+0.216** |         **0.043** |
+
+Up to 32 vCPU, speed costs ~½–¾ ¢ per minute saved; the 32→64 step costs **~6× more per minute** for the
+least time back. Cost per build rises monotonically with cores (sub-linear speedup × constant per-vCPU
+price), so the cheapest build is always the smallest.
+
+**3. Family: c6a wins ≤ 32 vCPU; m6a overtakes at 64.** c6a is cheaper at every size up to 32 (compute-
+bound → cheaper AMD compute). At 64 vCPU m6a is both faster (786 s vs 939 s) and cheaper ($0.603 vs
+$0.638): c6a's scaling stalls with 64 contending threads while m6a still gains — but this only matters
+inside the already-diseconomic zone.
+
+## Recommendation
+
+| goal | pick | $/build | wall |
+|------|------|--------:|-----:|
+| **cheapest** | c6a · 4 vCPU | $0.159 | 62 min |
+| balanced (the knee) | c6a · 32 vCPU | $0.422 | 21 min |
+| fastest | m6a · 64 vCPU | $0.603 | 13 min |
+
+**c6a is the family** (compute-optimized, cheapest at any sane size). For the default we optimise for
+cheapest $/build: **4 vCPU**. Push to 32 vCPU when a human is waiting; never 64.
+
+## Applied
+
+The coulomb and subduction builder `default_submission_args` were re-sized accordingly
+(`runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py`,
+`runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py`):
+
+| field | old | new | why |
+|-------|----:|----:|-----|
+| `ecs_vcpu` | 4 | 4 | cheapest $/build (unchanged) |
+| `java_threads` | 16 | 4 | track vCPU; 16-on-4 oversubscribed |
+| `ecs_memory` (MiB) | 30720 | 8192 | ~2 GB/vCPU; build is low-memory; avoids r-family on `"optimal"` |
+| `ecs_max_job_time_min` | 60 | 90 | the 4-vCPU build takes ~62 min — the old limit killed it |
+
+Subduction is assumed equivalent to coulomb (not independently benchmarked). Larger fault models or
+higher `max_sections` may shift the absolute times; re-run the matrix if the workload changes materially.
+
+## Out of scope
+
+Steering the shared compute environment off `"optimal"` (so it stops defaulting to r-family) or pinning
+Graviton/Spot is a deployer/terraform change, a follow-up only if the code-side default proves
+insufficient. Instance-type *pinning* here was only to keep the benchmark's family axis clean.

--- a/docs/benchmarks/ec2-sizing-crustal-inversion.md
+++ b/docs/benchmarks/ec2-sizing-crustal-inversion.md
@@ -106,9 +106,16 @@ flat across all families (~3135–3145): solution quality is identical; only cos
 - Applying either — changing the crustal default `SubmissionArgs` (currently 4 vCPU) and/or the CE's
   `ec2_instance_types` — is an architecture change and gets its own ADR, citing this benchmark.
 
-Memory floor caveat: c6a/c6i `.2xlarge` is 16 GiB (~12–14 GB heap). This rupture set converged fine
-there; a larger rupture set needing more heap would need a bigger compute-optimized size (c6a.4xlarge,
-32 GiB) or a general-purpose instance — re-check the memory floor before committing to c-family.
+**Applied (ADR-0011 + 2026-07-09):** the CE's `ec2_instance_types` was moved off `"optimal"` to
+`["c6a","m6a","c6i","m6i"]`, and the crustal **and** subduction inversion module defaults are now
+**8 vCPU / 14000 MiB, defaulting to the EC2 job definition** (`runzi-ec2-JD`). 14000 (not 16384) is used
+so the request clears the ECS agent/OS reservation on the 16 GiB `c*.2xlarge` and lands on c-family
+rather than general-purpose `m*.2xlarge`.
+
+Memory floor caveat: c6a/c6i `.2xlarge` is 16 GiB (~12 GB heap at 14000 MiB). This rupture set converged
+fine there, and subduction rupture sets are always smaller than crustal; a substantially larger crustal
+rupture set needing more heap would need a bigger compute-optimized size (c6a.4xlarge, 32 GiB) or a
+general-purpose instance — re-check the memory floor before relying on c-family for an outsized model.
 
 ## Caveats
 

--- a/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
+++ b/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
@@ -48,14 +48,16 @@ def get_fault_model_file(fault_model_file_id) -> Path:
 
 # Sizing from the EC2 benchmark (docs/benchmarks/ec2-sizing-coulomb-rupture-set.md): the build is
 # compute-bound and low-memory and scales sub-linearly, so 4 vCPU is the cheapest $/build. Threads track
-# vCPU (16-on-4 oversubscribed); memory is ~2 GB/vCPU (was 30 GB, which steered the shared "optimal" CE
-# onto expensive r-family); the time limit clears the ~62 min 4-vCPU build (was 60 min — it got killed).
+# vCPU (16-on-4 oversubscribed). Memory 7000 MiB (was 30 GB) sits just under the 8 GiB compute-optimized
+# c*.xlarge ceiling — with ECS agent/OS headroom, so the job fits c-family (the cheapest that fits under
+# BEST_FIT_PROGRESSIVE) instead of being bumped to general-purpose m*.xlarge (16 GiB) or expensive r.
+# The time limit clears the ~62 min 4-vCPU build (was 60 min — it got killed).
 default_submission_args = SubmissionArgs(
     task_language=TaskLanguage.JAVA,
     java_threads=4,
     jvm_heap_max=32,
     ecs_max_job_time_min=90,
-    ecs_memory=8192,
+    ecs_memory=7000,
     ecs_vcpu=4,
 )
 

--- a/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
+++ b/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
@@ -46,12 +46,16 @@ def get_fault_model_file(fault_model_file_id) -> Path:
     return Path(fault_model_archive_file_path).parent / fault_model_file
 
 
+# Sizing from the EC2 benchmark (docs/benchmarks/ec2-sizing-coulomb-rupture-set.md): the build is
+# compute-bound and low-memory and scales sub-linearly, so 4 vCPU is the cheapest $/build. Threads track
+# vCPU (16-on-4 oversubscribed); memory is ~2 GB/vCPU (was 30 GB, which steered the shared "optimal" CE
+# onto expensive r-family); the time limit clears the ~62 min 4-vCPU build (was 60 min — it got killed).
 default_submission_args = SubmissionArgs(
     task_language=TaskLanguage.JAVA,
-    java_threads=16,
+    java_threads=4,
     jvm_heap_max=32,
-    ecs_max_job_time_min=60,
-    ecs_memory=30720,
+    ecs_max_job_time_min=90,
+    ecs_memory=8192,
     ecs_vcpu=4,
 )
 

--- a/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
+++ b/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
@@ -14,7 +14,7 @@ from nshm_toshi_client.task_relation import TaskRelation
 from py4j.java_gateway import GatewayParameters, JavaGateway
 from pydantic import BaseModel, model_validator
 
-from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs
 from runzi.automation.file_utils import download_files, get_output_file_id
 from runzi.automation.local_config import API_URL, S3_URL, SPOOF, WORK_PATH, get_auth_kwargs
 from runzi.automation.toshi_api import ToshiApi
@@ -51,9 +51,12 @@ def get_fault_model_file(fault_model_file_id) -> Path:
 # vCPU (16-on-4 oversubscribed). Memory 7000 MiB (was 30 GB) sits just under the 8 GiB compute-optimized
 # c*.xlarge ceiling — with ECS agent/OS headroom, so the job fits c-family (the cheapest that fits under
 # BEST_FIT_PROGRESSIVE) instead of being bumped to general-purpose m*.xlarge (16 GiB) or expensive r.
-# The time limit clears the ~62 min 4-vCPU build (was 60 min — it got killed).
+# The time limit clears the ~62 min 4-vCPU build (was 60 min — it got killed). Defaults to the EC2 job
+# definition (not Fargate): these Java builds always run on the EC2 CE, and 7000 MiB / 4 vCPU is below
+# Fargate's 8192 MiB floor anyway.
 default_submission_args = SubmissionArgs(
     task_language=TaskLanguage.JAVA,
+    ecs_job_definition=EC2_JOB_DEFINITION,
     java_threads=4,
     jvm_heap_max=32,
     ecs_max_job_time_min=90,

--- a/runzi/tasks/inversion/crustal_inversion_solution_task.py
+++ b/runzi/tasks/inversion/crustal_inversion_solution_task.py
@@ -24,16 +24,15 @@ default_submission_args = SubmissionArgs(
     # are swept args. It would be possible to add some inversion specific code to the build_tasks function or find the
     # maximum number of threads before hand or find the maximum number of threads that would be needed before hand.
     java_threads=16,
-    # 8 vCPU / 16 GB (2:1) is the iterations-per-dollar sweet spot from the #323 benchmark (ADR-0011):
-    # the fixed 16-thread anneal saturates ~8 cores, and the inversion converged at ~14 GB heap. On AWS
-    # the heap is derived from ecs_memory (memory/1000-2); jvm_heap_max is the LOCAL/CLUSTER -Xmx, kept
-    # in step. Defaults to EC2 (compute-bound winner, #323). NB: 16384 = the full 16 GiB of c*.2xlarge,
-    # so after the ECS agent/OS reservation the job lands on general-purpose m*.2xlarge; drop to ~14000
-    # to fit compute-optimized c-family (heap ~12 GB, which #323 ran crustal on successfully).
+    # 8 vCPU / ~14 GB is the iterations-per-dollar sweet spot from the #323 benchmark (ADR-0011): the
+    # fixed 16-thread anneal saturates ~8 cores. Defaults to EC2, and 14000 MiB sits just under the 16 GiB
+    # of compute-optimized c*.2xlarge (leaving ECS agent/OS headroom), so BEST_FIT_PROGRESSIVE places it
+    # on cheap c-family rather than general-purpose m*.2xlarge. On AWS heap = memory/1000-2 ≈ 12 GB (what
+    # #323 ran crustal on successfully); jvm_heap_max is the LOCAL/CLUSTER -Xmx, kept in step.
     ecs_job_definition=EC2_JOB_DEFINITION,
-    jvm_heap_max=14,
+    jvm_heap_max=12,
     ecs_max_job_time_min=60,
-    ecs_memory=16384,
+    ecs_memory=14000,
     ecs_vcpu=8,
 )
 

--- a/runzi/tasks/inversion/crustal_inversion_solution_task.py
+++ b/runzi/tasks/inversion/crustal_inversion_solution_task.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 import git
 from pydantic import BaseModel, model_validator
 
-from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs
 from runzi.automation.file_utils import download_files, get_output_file_id
 from runzi.automation.local_config import WORK_PATH
 from runzi.automation.toshi_api import ModelType
@@ -27,7 +27,10 @@ default_submission_args = SubmissionArgs(
     # 8 vCPU / 16 GB (2:1) is the iterations-per-dollar sweet spot from the #323 benchmark (ADR-0011):
     # the fixed 16-thread anneal saturates ~8 cores, and the inversion converged at ~14 GB heap. On AWS
     # the heap is derived from ecs_memory (memory/1000-2); jvm_heap_max is the LOCAL/CLUSTER -Xmx, kept
-    # in step. 16384 is also the minimum valid Fargate memory at 8 vCPU.
+    # in step. Defaults to EC2 (compute-bound winner, #323). NB: 16384 = the full 16 GiB of c*.2xlarge,
+    # so after the ECS agent/OS reservation the job lands on general-purpose m*.2xlarge; drop to ~14000
+    # to fit compute-optimized c-family (heap ~12 GB, which #323 ran crustal on successfully).
+    ecs_job_definition=EC2_JOB_DEFINITION,
     jvm_heap_max=14,
     ecs_max_job_time_min=60,
     ecs_memory=16384,

--- a/runzi/tasks/inversion/subduction_inversion_solution_task.py
+++ b/runzi/tasks/inversion/subduction_inversion_solution_task.py
@@ -18,16 +18,15 @@ default_submission_args = SubmissionArgs(
     # are swept args. It would be possible to add some inversion specific code to the build_tasks function or find the
     # maximum number of threads before hand or find the maximum number of threads that would be needed before hand.
     java_threads=16,
-    # 8 vCPU / 16 GB (2:1) per the #323 crustal benchmark (ADR-0011). Subduction was not benchmarked
-    # directly; if a large subduction rupture set OOMs at ~14 GB heap, raise ecs_memory (e.g. 32768).
-    # On AWS the heap derives from ecs_memory (memory/1000-2); jvm_heap_max is the LOCAL/CLUSTER -Xmx.
-    # Defaults to EC2 (compute-bound, mirrors crustal). NB: 16384 = the full 16 GiB of c*.2xlarge, so with
-    # ECS overhead the job lands on general-purpose m*.2xlarge; dropping to ~14000 would fit c-family but
-    # cuts the heap to ~12 GB — risky for large subduction rupture sets, so left at 16384.
+    # 8 vCPU / ~14 GB, mirroring the crustal #323 sizing (ADR-0011). Defaults to EC2, and 14000 MiB fits
+    # compute-optimized c*.2xlarge (16 GiB) with ECS headroom, so it lands on cheap c-family rather than
+    # general-purpose m*.2xlarge. Heap = memory/1000-2 ≈ 12 GB — safe because subduction rupture sets are
+    # always smaller than crustal (which ran fine at this heap in #323). On AWS heap derives from
+    # ecs_memory; jvm_heap_max is the LOCAL/CLUSTER -Xmx, kept in step.
     ecs_job_definition=EC2_JOB_DEFINITION,
-    jvm_heap_max=14,
+    jvm_heap_max=12,
     ecs_max_job_time_min=60,
-    ecs_memory=16384,
+    ecs_memory=14000,
     ecs_vcpu=8,
 )
 

--- a/runzi/tasks/inversion/subduction_inversion_solution_task.py
+++ b/runzi/tasks/inversion/subduction_inversion_solution_task.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, cast
 
 import git
 
-from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs
 from runzi.automation.toshi_api import ModelType
 from runzi.tasks.get_config import get_config
 from runzi.tasks.inversion.inversion_solution_builder import InversionArgs, InversionSolutionBuilder
@@ -21,6 +21,10 @@ default_submission_args = SubmissionArgs(
     # 8 vCPU / 16 GB (2:1) per the #323 crustal benchmark (ADR-0011). Subduction was not benchmarked
     # directly; if a large subduction rupture set OOMs at ~14 GB heap, raise ecs_memory (e.g. 32768).
     # On AWS the heap derives from ecs_memory (memory/1000-2); jvm_heap_max is the LOCAL/CLUSTER -Xmx.
+    # Defaults to EC2 (compute-bound, mirrors crustal). NB: 16384 = the full 16 GiB of c*.2xlarge, so with
+    # ECS overhead the job lands on general-purpose m*.2xlarge; dropping to ~14000 would fit c-family but
+    # cuts the heap to ~12 GB — risky for large subduction rupture sets, so left at 16384.
+    ecs_job_definition=EC2_JOB_DEFINITION,
     jvm_heap_max=14,
     ecs_max_job_time_min=60,
     ecs_memory=16384,

--- a/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
+++ b/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
@@ -27,14 +27,15 @@ logging.getLogger('urllib3').setLevel(loglevel)
 logging.getLogger('git.cmd').setLevel(loglevel)
 
 # Sizing mirrors the coulomb builder (docs/benchmarks/ec2-sizing-coulomb-rupture-set.md): compute-bound,
-# low-memory, sub-linear scaling -> 4 vCPU cheapest, threads track vCPU, memory ~2 GB/vCPU, time limit
-# clears the slow low-vCPU build. Assumed equivalent to coulomb (not independently benchmarked).
+# low-memory, sub-linear scaling -> 4 vCPU cheapest, threads track vCPU, memory 7000 MiB (fits the 8 GiB
+# compute-optimized c*.xlarge with ECS headroom, so BEST_FIT_PROGRESSIVE picks c not m), time limit clears
+# the slow low-vCPU build. Assumed equivalent to coulomb (not independently benchmarked).
 default_submission_args = SubmissionArgs(
     task_language=TaskLanguage.JAVA,
     java_threads=4,
     jvm_heap_max=32,
     ecs_max_job_time_min=90,
-    ecs_memory=8192,
+    ecs_memory=7000,
     ecs_vcpu=4,
 )
 

--- a/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
+++ b/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
@@ -12,7 +12,7 @@ from nshm_toshi_client.task_relation import TaskRelation
 from py4j.java_gateway import GatewayParameters, JavaGateway
 from pydantic import BaseModel
 
-from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs
 from runzi.automation.local_config import API_URL, S3_URL, SPOOF, WORK_PATH, get_auth_kwargs
 from runzi.tasks.get_config import get_config
 
@@ -29,9 +29,11 @@ logging.getLogger('git.cmd').setLevel(loglevel)
 # Sizing mirrors the coulomb builder (docs/benchmarks/ec2-sizing-coulomb-rupture-set.md): compute-bound,
 # low-memory, sub-linear scaling -> 4 vCPU cheapest, threads track vCPU, memory 7000 MiB (fits the 8 GiB
 # compute-optimized c*.xlarge with ECS headroom, so BEST_FIT_PROGRESSIVE picks c not m), time limit clears
-# the slow low-vCPU build. Assumed equivalent to coulomb (not independently benchmarked).
+# the slow low-vCPU build. Defaults to the EC2 job definition (these Java builds always run on the EC2 CE,
+# and 7000 MiB / 4 vCPU is below Fargate's floor). Assumed equivalent to coulomb (not independently benchmarked).
 default_submission_args = SubmissionArgs(
     task_language=TaskLanguage.JAVA,
+    ecs_job_definition=EC2_JOB_DEFINITION,
     java_threads=4,
     jvm_heap_max=32,
     ecs_max_job_time_min=90,

--- a/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
+++ b/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
@@ -26,12 +26,15 @@ logging.getLogger('nshm_toshi_client.toshi_file').setLevel(loglevel)
 logging.getLogger('urllib3').setLevel(loglevel)
 logging.getLogger('git.cmd').setLevel(loglevel)
 
+# Sizing mirrors the coulomb builder (docs/benchmarks/ec2-sizing-coulomb-rupture-set.md): compute-bound,
+# low-memory, sub-linear scaling -> 4 vCPU cheapest, threads track vCPU, memory ~2 GB/vCPU, time limit
+# clears the slow low-vCPU build. Assumed equivalent to coulomb (not independently benchmarked).
 default_submission_args = SubmissionArgs(
     task_language=TaskLanguage.JAVA,
-    java_threads=16,
+    java_threads=4,
     jvm_heap_max=32,
-    ecs_max_job_time_min=60,
-    ecs_memory=30720,
+    ecs_max_job_time_min=90,
+    ecs_memory=8192,
     ecs_vcpu=4,
 )
 

--- a/scripts/ec2_sizing/README.md
+++ b/scripts/ec2_sizing/README.md
@@ -87,3 +87,75 @@ Instance-type *pinning* (Graviton/arm64, Spot vs On-Demand) is the direct #323 "
 question and needs a deployer Terraform apply — a follow-up only if these sizing results are ambiguous.
 Acting on the results (changing the CE's `instance_types` or the crustal default `SubmissionArgs`) is
 an architecture change and gets its own ADR.
+
+---
+
+# EC2 job-sizing benchmark for the coulomb rupture-set builder
+
+Same idea, different task and **different metric**. The coulomb builder (`runzi rupset coulomb`) runs
+**to completion** (~20 min), so wall time is the signal, not throughput: we ask *how fast / how cheaply
+does a build finish, and where do extra cores stop paying?* This is a strict subtraction from the
+inversion collector — wall time comes straight off the Batch job summary, so there is **no Toshi log to
+parse** (no `--iteration-regex`).
+
+## What it measures
+
+- **Cores.** vCPU `{4, 8, 16, 32}` with **`java_threads` pinned to `ecs_vcpu`** per cell (the builder
+  calls `setNumThreads(java_threads)`), so each cell actually uses the cores it pays for and the
+  wall-time-vs-cores curve is meaningful. We do *not* know a priori whether the builder parallelizes —
+  the curve answers it: falling wall time ⇒ it scales (pick the knee); flat ⇒ it doesn't (run smallest).
+- **Instance family.** `c6a` (compute-optimized) vs `m6a` (general purpose), both AMD (cheapest x86),
+  **pinned** via per-family Batch queues from `terraform/ec2-sizing-benchmark/`. `ecs_memory` is sized to
+  ~fill each family's per-vCPU RAM (c ≈ 1.8 GB/vCPU, m ≈ 3.8 GB/vCPU), so a c-family **OOM is the finding**
+  that the build needs more than 2 GB/vCPU and must run on m-family.
+
+Cost is the same fair-share `(instance $/hr / instance vCPU) × job vCPU × wall-hours`, priced from the
+instance Batch placed each job on. The summary ranks cells by **mean cost per build** (cheapest first)
+with **mean wall seconds** alongside, so the cost knee and time knee are visible together.
+
+## Workflow
+
+```bash
+# 0. Dry run — confirm the 16 cells render valid EC2-targeted configs (no AWS calls).
+uv run python scripts/ec2_sizing/submit_coulomb_matrix.py --dry-run --queue-prefix ec2sizing
+
+# 1. Stand up the pinned per-family queues (once): from terraform/ec2-sizing-benchmark/ with
+#    instance_types = ["c6a","m6a"] (bare family names → any size in the family, so vCPU can sweep).
+#    NB: VERIFY AWS Batch accepts bare family names; if a plan/apply rejects them, fall back to
+#    enumerating sizes: ["c6a.xlarge","c6a.2xlarge","c6a.4xlarge","c6a.8xlarge", + the m6a set].
+#    `terraform output queues` prints {family -> queue}; name_prefix defaults to "ec2sizing".
+
+# 2. PILOT (the key risk): ONE cell to confirm the deployed :experimental worker isn't stale (#323 hit a
+#    py4j 127.0.0.1:None from an out-of-date image) AND that the wall-clock path works end-to-end.
+uv run python scripts/ec2_sizing/submit_coulomb_matrix.py \
+    --limit 1 --queue-prefix ec2sizing --manifest scratch/coulomb_pilot.json
+#    ...wait for the job to finish, then:
+uv run python scripts/ec2_sizing/collect_coulomb_results.py \
+    --manifest scratch/coulomb_pilot.json --csv scratch/coulomb_pilot.csv
+#    A real duration_sec (and a priced cost, if you have the ECS/EC2 read perms) proves the pipeline.
+
+# 3. Full matrix — 16 submits (2 families × 4 vCPU × 2 replicates).
+uv run python scripts/ec2_sizing/submit_coulomb_matrix.py \
+    --queue-prefix ec2sizing --manifest scripts/ec2_sizing/coulomb_manifest.json
+
+# 4. Collect + analyse once the jobs finish (terminal Batch jobs age out ~24h — collect promptly).
+uv run python scripts/ec2_sizing/collect_coulomb_results.py \
+    --manifest scripts/ec2_sizing/coulomb_manifest.json --csv scripts/ec2_sizing/coulomb_results.csv
+#    Cost needs no ECS read-back for a pinned run: the instance is derived from family + vCPU, and the
+#    fair-share per-vCPU rate is identical across sizes within a family. So even after the pinned CEs
+#    scale to zero (ECS can no longer resolve the instance), re-running the collector still prices every
+#    cell. (--instance-type is only for an *unpinned* run whose CE has scaled to zero.)
+```
+
+Then `terraform destroy` the benchmark module (the shared `runzi-ec2-CE` is untouched). Each build
+uploads a real rupture set to Toshi (`USE_API` is required to mint the `general_task_id` that links back
+to the Batch job) — note the ~16 throwaway uploads for cleanup.
+
+## Coulomb files
+
+- `coulomb_rupture_set.template.json` — base config (fault model `CFM_1_0A_DOM_SANSTVZ`, `max_sections`
+  2000); `submit_coulomb_matrix.py` injects per-cell `ecs_vcpu` / `java_threads` / `ecs_memory`.
+- `submit_coulomb_matrix.py` — renders + submits the family × vCPU matrix, writes `coulomb_manifest.json`.
+- `collect_coulomb_results.py` — joins the manifest to live Batch/EC2 data → CSV + summary (wall time +
+  cost, no Toshi).
+- `_cost.py` — the EC2 price table + fair-share cost formula, shared with the inversion collector.

--- a/scripts/ec2_sizing/_cost.py
+++ b/scripts/ec2_sizing/_cost.py
@@ -1,0 +1,116 @@
+"""Shared cost primitives for the EC2 sizing benchmarks (#323).
+
+The EC2 On-Demand price table and the fair-share cost formula are task-agnostic, so both the crustal
+inversion collector (``collect_results.py``) and the coulomb rupture-set collector
+(``collect_coulomb_results.py``) import them from here — one price table, no drift.
+
+Cost is analytical, not raw billing: a benchmark under-packs instances, so we charge each job only for
+the vCPUs it requested — ``(instance $/hr / instance vCPU) x job vCPU x wall-hours`` — the cost it would
+carry on a fully-packed production instance.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# EC2 On-Demand price table, us-east-1, Linux: (vcpu, usd_per_hour). AWS Batch "optimal" resolves to
+# CURRENT-gen C/M/R families (a pilot landed on m6i.xlarge), not the legacy C4/M4/R4, so the modern
+# generations are covered here; the older ones are kept as a harmless fallback. Prices are APPROXIMATE —
+# REFRESH from the AWS pricing page before trusting cost figures. Instances not listed leave cost blank
+# and trigger a warning (add them here). last verified: 2026-07
+INSTANCE_SPECS: dict[str, tuple[int, float]] = {
+    # general purpose (M)
+    'm6i.large': (2, 0.096),
+    'm6i.xlarge': (4, 0.192),
+    'm6i.2xlarge': (8, 0.384),
+    'm6i.4xlarge': (16, 0.768),
+    'm6i.8xlarge': (32, 1.536),
+    'm6i.12xlarge': (48, 2.304),
+    'm6i.16xlarge': (64, 3.072),
+    'm5.large': (2, 0.096),
+    'm5.xlarge': (4, 0.192),
+    'm5.2xlarge': (8, 0.384),
+    'm5.4xlarge': (16, 0.768),
+    'm5.8xlarge': (32, 1.536),
+    'm5.12xlarge': (48, 2.304),
+    'm5.16xlarge': (64, 3.072),
+    # compute optimized (C)
+    'c6i.large': (2, 0.085),
+    'c6i.xlarge': (4, 0.170),
+    'c6i.2xlarge': (8, 0.340),
+    'c6i.4xlarge': (16, 0.680),
+    'c6i.8xlarge': (32, 1.360),
+    'c6i.12xlarge': (48, 2.040),
+    'c6i.16xlarge': (64, 2.720),
+    'c5.large': (2, 0.085),
+    'c5.xlarge': (4, 0.170),
+    'c5.2xlarge': (8, 0.340),
+    'c5.4xlarge': (16, 0.680),
+    'c5.9xlarge': (36, 1.530),
+    'c5.12xlarge': (48, 2.040),
+    'c5.18xlarge': (72, 3.060),
+    'c5.24xlarge': (96, 4.080),
+    # memory optimized (R)
+    'r6i.large': (2, 0.126),
+    'r6i.xlarge': (4, 0.252),
+    'r6i.2xlarge': (8, 0.504),
+    'r6i.4xlarge': (16, 1.008),
+    'r6i.8xlarge': (32, 2.016),
+    'r6i.12xlarge': (48, 3.024),
+    'r6i.16xlarge': (64, 4.032),
+    'r5.large': (2, 0.126),
+    'r5.xlarge': (4, 0.252),
+    'r5.2xlarge': (8, 0.504),
+    'r5.4xlarge': (16, 1.008),
+    'r5.8xlarge': (32, 2.016),
+    'r5.12xlarge': (48, 3.024),
+    'r5.16xlarge': (64, 4.032),
+    # AMD (c6a/m6a/r6a) — same x86 arch as the Intel i-variants, ~10% cheaper (Phase 2 comparison)
+    'c6a.large': (2, 0.0765),
+    'c6a.xlarge': (4, 0.153),
+    'c6a.2xlarge': (8, 0.306),
+    'c6a.4xlarge': (16, 0.612),
+    'c6a.8xlarge': (32, 1.224),
+    'c6a.12xlarge': (48, 1.836),
+    'c6a.16xlarge': (64, 2.448),
+    'm6a.large': (2, 0.0864),
+    'm6a.xlarge': (4, 0.1728),
+    'm6a.2xlarge': (8, 0.3456),
+    'm6a.4xlarge': (16, 0.6912),
+    'm6a.8xlarge': (32, 1.3824),
+    'm6a.12xlarge': (48, 2.0736),
+    'm6a.16xlarge': (64, 2.7648),
+    'r6a.large': (2, 0.1134),
+    'r6a.xlarge': (4, 0.2268),
+    'r6a.2xlarge': (8, 0.4536),
+    'r6a.4xlarge': (16, 0.9072),
+    'r6a.8xlarge': (32, 1.8144),
+    'r6a.12xlarge': (48, 2.7216),
+    'r6a.16xlarge': (64, 3.6288),
+    # legacy fallback (pre-current-gen "optimal")
+    'c4.xlarge': (4, 0.199),
+    'c4.2xlarge': (8, 0.398),
+    'c4.4xlarge': (16, 0.796),
+    'm4.xlarge': (4, 0.200),
+    'm4.2xlarge': (8, 0.400),
+    'm4.4xlarge': (16, 0.800),
+    'r4.xlarge': (4, 0.266),
+    'r4.2xlarge': (8, 0.532),
+    'r4.4xlarge': (16, 1.064),
+}
+
+
+def duration_seconds(summary: dict[str, Any]) -> float | None:
+    """Wall seconds from a Batch JobSummary's epoch-millis timestamps, or ``None`` if not both present."""
+    started, stopped = summary.get('startedAt'), summary.get('stoppedAt')
+    if started is None or stopped is None:
+        return None
+    return max(0.0, (stopped - started) / 1000.0)
+
+
+def job_cost_usd(instance_type: str | None, job_vcpu: int, seconds: float | None) -> float | None:
+    """Fair-share cost = (instance $/hr / instance vCPU) x job vCPU x hours; ``None`` if unpriceable."""
+    if instance_type is None or seconds is None or instance_type not in INSTANCE_SPECS:
+        return None
+    instance_vcpu, usd_per_hour = INSTANCE_SPECS[instance_type]
+    return (usd_per_hour / instance_vcpu) * job_vcpu * (seconds / 3600.0)

--- a/scripts/ec2_sizing/collect_coulomb_results.py
+++ b/scripts/ec2_sizing/collect_coulomb_results.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+"""Collect and analyse the EC2 job-sizing benchmark for the coulomb rupture-set builder (#323).
+
+The coulomb builder runs *to completion*, so the metric is **wall-clock time** (lower = better) and the
+efficiency figure is **cost per completed build**. Both come straight from the AWS Batch job summary +
+the instance type Batch placed the job on — there is **no Toshi log to parse** (that's inversion-only).
+
+Given the manifest written by ``submit_coulomb_matrix.py``, this builds one row per cell with: the EC2
+instance type, wall duration, and the fair-share cost. Emits a CSV and prints a per-cell summary ranked
+by mean cost (cheapest first) with mean duration alongside, so both knees — cost-vs-vCPU and
+time-vs-vCPU — are visible.
+
+Cost is analytical, not raw billing: a benchmark under-packs instances, so we charge each job only for
+the vCPUs it requested (see ``_cost.py``).
+
+Usage::
+
+    python scripts/ec2_sizing/collect_coulomb_results.py \
+        --manifest scripts/ec2_sizing/coulomb_manifest.json --csv scripts/ec2_sizing/coulomb_results.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+from runzi.arguments import DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE
+from runzi.aws.batch_query import instance_type_by_job_id, jobs_for_general_task
+
+# These scripts are loaded by file path (not as a package), so bootstrap the sibling module onto sys.path.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _cost import INSTANCE_SPECS, duration_seconds, job_cost_usd  # noqa: E402
+
+# Exact-fit instance size for a given vCPU (job vCPU = instance vCPU on a pinned, one-job-per-size run).
+VCPU_TO_SIZE = {2: 'large', 4: 'xlarge', 8: '2xlarge', 16: '4xlarge', 32: '8xlarge', 48: '12xlarge', 64: '16xlarge'}
+
+
+def expected_instance_type(family: str | None, vcpu: int | None) -> str | None:
+    """The exact-fit instance type for a pinned family + vCPU (e.g. c6a + 8 -> c6a.2xlarge), or ``None``.
+
+    On a family-pinned run the instance is deterministic from family + vCPU, so we can price a run whose
+    compute environment has already scaled to zero (ECS can no longer resolve the instance) without any
+    read-back. And because $/hr scales linearly with size, the fair-share **per-vCPU** cost is identical
+    whatever size Batch actually packed the job onto — so this stays correct even if Batch co-located jobs.
+    """
+    if not family or vcpu not in VCPU_TO_SIZE:
+        return None
+    candidate = f'{family}.{VCPU_TO_SIZE[vcpu]}'
+    return candidate if candidate in INSTANCE_SPECS else None
+
+
+def collect_rows(
+    manifest: dict[str, Any],
+    queues: tuple[str, ...] = (DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE),
+    instance_type_override: str | None = None,
+) -> list[dict[str, Any]]:
+    """Build one result row per manifest cell, joining Batch/EC2 wall duration with fair-share cost.
+
+    ``queues`` is the set of Batch job queues to search for each cell's job — must include any pinned
+    per-family benchmark queue, since those aren't in the standard set.
+
+    ``instance_type_override`` forces the instance type for every row (a pinned run whose compute
+    environment has since scaled to zero, so ECS can no longer resolve the instance), skipping the
+    ECS/EC2 lookup.
+    """
+    rows_by_gt_id = {row['general_task_id']: row for row in manifest['rows']}
+
+    # Each cell is its own submit -> one general task -> one Batch job. Fetch each cell's job(s) once,
+    # then price all instance types in a single batched lookup (unless the type is pinned/overridden).
+    jobs_by_gt_id = {gt_id: jobs_for_general_task(gt_id, queues=queues) for gt_id in rows_by_gt_id}
+    all_job_ids = [job['jobId'] for jobs in jobs_by_gt_id.values() for job in jobs]
+    instance_types: dict[str, str] = {}
+    if instance_type_override is None:
+        try:
+            instance_types = instance_type_by_job_id(all_job_ids)
+        except ClientError as exc:
+            # Resolving instance types needs ecs:DescribeContainerInstances + ec2:DescribeInstances.
+            # Without them we still report status/duration; only cost goes blank.
+            print(f'warning: cannot resolve EC2 instance types, cost columns will be blank: {exc}', file=sys.stderr)
+
+    results: list[dict[str, Any]] = []
+    for gt_id, cell in rows_by_gt_id.items():
+        jobs = jobs_by_gt_id[gt_id]
+        summary = jobs[0] if jobs else {}  # oldest job; a coulomb submit produces exactly one
+        job_id = summary.get('jobId')
+        # Prefer the resolved type; fall back to the family-derived exact-fit type for pinned cells (rows
+        # routed to a per-family queue), so cost survives the CE scaling to zero / no ECS read-back perms.
+        derived = expected_instance_type(cell.get('family'), cell['vcpu']) if cell.get('job_queue') else None
+        instance_type = instance_type_override or (instance_types.get(job_id) if job_id else None) or derived
+        seconds = duration_seconds(summary)
+        cost = job_cost_usd(instance_type, cell['vcpu'], seconds)
+        results.append(
+            {
+                'cell_id': cell['cell_id'],
+                'family': cell['family'],
+                'vcpu': cell['vcpu'],
+                'threads': cell.get('threads', cell['vcpu']),
+                'memory_mb': cell['memory_mb'],
+                'replicate': cell['replicate'],
+                'general_task_id': gt_id,
+                'job_id': job_id,
+                'status': summary.get('status'),
+                'instance_type': instance_type,
+                'duration_sec': None if seconds is None else round(seconds, 1),
+                'cost_usd': None if cost is None else round(cost, 5),
+            }
+        )
+    return results
+
+
+FIELDNAMES = [
+    'cell_id',
+    'family',
+    'vcpu',
+    'threads',
+    'memory_mb',
+    'replicate',
+    'general_task_id',
+    'job_id',
+    'status',
+    'instance_type',
+    'duration_sec',
+    'cost_usd',
+]
+
+
+def write_csv(rows: list[dict[str, Any]], path: Path) -> None:
+    with path.open('w', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _mean(values: list[float]) -> float | None:
+    return statistics.mean(values) if values else None
+
+
+def _fmt(value: object, unit: str = '') -> str:
+    """Format a summary number: integer resolution, underscore thousands separators, or 'None'."""
+    if not isinstance(value, (int, float)):
+        return 'None'
+    return f'{round(value):_}{unit}'
+
+
+def _fmt_cost(value: object) -> str:
+    return 'None' if not isinstance(value, (int, float)) else f'${value:.4f}'
+
+
+def print_summary(rows: list[dict[str, Any]]) -> None:
+    """Print a per-cell (family x vCPU) summary ranked by mean cost per build (cheapest first).
+
+    Mean wall duration is shown alongside so the time-vs-vCPU knee is visible next to the cost-vs-vCPU
+    knee. Cells with no priced cost (unresolved instance, or a failed/OOM build) sort last.
+    """
+    by_cell: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_cell[(row['family'], row['vcpu'])].append(row)
+
+    summary = []
+    for (family, vcpu), cell_rows in by_cell.items():
+        durations = [r['duration_sec'] for r in cell_rows if r['duration_sec'] is not None]
+        costs = [r['cost_usd'] for r in cell_rows if r['cost_usd'] is not None]
+        statuses = sorted({r['status'] for r in cell_rows if r['status']})
+        instances = sorted({r['instance_type'] for r in cell_rows if r['instance_type']})
+        summary.append(
+            {
+                'family': family,
+                'vcpu': vcpu,
+                'n': len(cell_rows),
+                'instances': ','.join(instances) or '-',
+                'status': ','.join(statuses) or '-',
+                'mean_duration': _mean(durations),
+                'mean_cost': _mean(costs),
+            }
+        )
+    # Cheapest first; unpriced cells (mean_cost None) sort to the bottom.
+    summary.sort(key=lambda s: (s['mean_cost'] is None, s['mean_cost'] or 0.0))
+
+    header = f'{"family":>7} {"vCPU":>4} {"n":>3} {"instances":>16} {"status":>18} {"mean_secs":>10} {"mean_cost":>11}'
+    print(header)
+    print('-' * len(header))
+    for s in summary:
+        print(
+            f'{s["family"]:>7} {s["vcpu"]:>4} {s["n"]:>3} {s["instances"]:>16} {s["status"]:>18} '
+            f'{_fmt(s["mean_duration"], "s"):>10} {_fmt_cost(s["mean_cost"]):>11}'
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        '--manifest',
+        type=Path,
+        default=Path(__file__).with_name('coulomb_manifest.json'),
+        help='Manifest from submit_coulomb_matrix.py.',
+    )
+    parser.add_argument(
+        '--csv',
+        type=Path,
+        default=Path(__file__).with_name('coulomb_results.csv'),
+        help='Where to write the per-job CSV.',
+    )
+    parser.add_argument(
+        '--queues',
+        nargs='+',
+        default=None,
+        help="Batch job queues to search (default: the manifest's per-cell queues plus the standard queues).",
+    )
+    parser.add_argument(
+        '--instance-type',
+        default=None,
+        help='Force the instance type for every row (a pinned run whose compute environment has scaled to zero, '
+        'when ECS can no longer resolve the instance).',
+    )
+    args = parser.parse_args(argv)
+
+    manifest = json.loads(args.manifest.read_text())
+    # Search the manifest's own per-cell queues (pinned benchmark queues aren't in the standard set) plus
+    # the standard queues, unless --queues overrides. dict.fromkeys de-dupes while keeping order.
+    if args.queues:
+        queues = tuple(args.queues)
+    else:
+        manifest_queues = [row.get('job_queue') for row in manifest['rows']]
+        queues = tuple(dict.fromkeys([q for q in (*manifest_queues, DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE) if q]))
+    rows = collect_rows(manifest, queues=queues, instance_type_override=args.instance_type)
+    write_csv(rows, args.csv)
+    print(f'wrote {len(rows)} rows to {args.csv}\n')
+
+    unpriced = sorted(
+        {r['instance_type'] for r in rows if r['instance_type'] and r['instance_type'] not in INSTANCE_SPECS}
+    )
+    if unpriced:
+        print(f'warning: no price for {", ".join(unpriced)} — add to _cost.py for their cost.\n', file=sys.stderr)
+
+    print_summary(rows)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ec2_sizing/collect_results.py
+++ b/scripts/ec2_sizing/collect_results.py
@@ -41,94 +41,13 @@ from botocore.exceptions import ClientError
 from runzi.arguments import DEFAULT_JOB_QUEUE, EC2_JOB_QUEUE
 from runzi.aws.batch_query import instance_type_by_job_id, jobs_for_general_task
 
+# The EC2 price table + fair-share cost formula are task-agnostic and shared with the coulomb collector.
+# These scripts are loaded by file path (not as a package), so bootstrap the sibling module onto sys.path.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _cost import INSTANCE_SPECS, duration_seconds, job_cost_usd  # noqa: E402
+
 if TYPE_CHECKING:
     from runzi.automation.toshi_api import ToshiApi
-
-# EC2 On-Demand price table, us-east-1, Linux: (vcpu, usd_per_hour). AWS Batch "optimal" resolves to
-# CURRENT-gen C/M/R families (a pilot landed on m6i.xlarge), not the legacy C4/M4/R4, so the modern
-# generations are covered here; the older ones are kept as a harmless fallback. Prices are APPROXIMATE —
-# REFRESH from the AWS pricing page before trusting cost figures. Instances not listed leave cost blank
-# and trigger a warning (add them here). last verified: 2026-07
-INSTANCE_SPECS: dict[str, tuple[int, float]] = {
-    # general purpose (M)
-    'm6i.large': (2, 0.096),
-    'm6i.xlarge': (4, 0.192),
-    'm6i.2xlarge': (8, 0.384),
-    'm6i.4xlarge': (16, 0.768),
-    'm6i.8xlarge': (32, 1.536),
-    'm6i.12xlarge': (48, 2.304),
-    'm6i.16xlarge': (64, 3.072),
-    'm5.large': (2, 0.096),
-    'm5.xlarge': (4, 0.192),
-    'm5.2xlarge': (8, 0.384),
-    'm5.4xlarge': (16, 0.768),
-    'm5.8xlarge': (32, 1.536),
-    'm5.12xlarge': (48, 2.304),
-    'm5.16xlarge': (64, 3.072),
-    # compute optimized (C)
-    'c6i.large': (2, 0.085),
-    'c6i.xlarge': (4, 0.170),
-    'c6i.2xlarge': (8, 0.340),
-    'c6i.4xlarge': (16, 0.680),
-    'c6i.8xlarge': (32, 1.360),
-    'c6i.12xlarge': (48, 2.040),
-    'c6i.16xlarge': (64, 2.720),
-    'c5.large': (2, 0.085),
-    'c5.xlarge': (4, 0.170),
-    'c5.2xlarge': (8, 0.340),
-    'c5.4xlarge': (16, 0.680),
-    'c5.9xlarge': (36, 1.530),
-    'c5.12xlarge': (48, 2.040),
-    'c5.18xlarge': (72, 3.060),
-    'c5.24xlarge': (96, 4.080),
-    # memory optimized (R)
-    'r6i.large': (2, 0.126),
-    'r6i.xlarge': (4, 0.252),
-    'r6i.2xlarge': (8, 0.504),
-    'r6i.4xlarge': (16, 1.008),
-    'r6i.8xlarge': (32, 2.016),
-    'r6i.12xlarge': (48, 3.024),
-    'r6i.16xlarge': (64, 4.032),
-    'r5.large': (2, 0.126),
-    'r5.xlarge': (4, 0.252),
-    'r5.2xlarge': (8, 0.504),
-    'r5.4xlarge': (16, 1.008),
-    'r5.8xlarge': (32, 2.016),
-    'r5.12xlarge': (48, 3.024),
-    'r5.16xlarge': (64, 4.032),
-    # AMD (c6a/m6a/r6a) — same x86 arch as the Intel i-variants, ~10% cheaper (Phase 2 comparison)
-    'c6a.large': (2, 0.0765),
-    'c6a.xlarge': (4, 0.153),
-    'c6a.2xlarge': (8, 0.306),
-    'c6a.4xlarge': (16, 0.612),
-    'c6a.8xlarge': (32, 1.224),
-    'c6a.12xlarge': (48, 1.836),
-    'c6a.16xlarge': (64, 2.448),
-    'm6a.large': (2, 0.0864),
-    'm6a.xlarge': (4, 0.1728),
-    'm6a.2xlarge': (8, 0.3456),
-    'm6a.4xlarge': (16, 0.6912),
-    'm6a.8xlarge': (32, 1.3824),
-    'm6a.12xlarge': (48, 2.0736),
-    'm6a.16xlarge': (64, 2.7648),
-    'r6a.large': (2, 0.1134),
-    'r6a.xlarge': (4, 0.2268),
-    'r6a.2xlarge': (8, 0.4536),
-    'r6a.4xlarge': (16, 0.9072),
-    'r6a.8xlarge': (32, 1.8144),
-    'r6a.12xlarge': (48, 2.7216),
-    'r6a.16xlarge': (64, 3.6288),
-    # legacy fallback (pre-current-gen "optimal")
-    'c4.xlarge': (4, 0.199),
-    'c4.2xlarge': (8, 0.398),
-    'c4.4xlarge': (16, 0.796),
-    'm4.xlarge': (4, 0.200),
-    'm4.2xlarge': (8, 0.400),
-    'm4.4xlarge': (16, 0.800),
-    'r4.xlarge': (4, 0.266),
-    'r4.2xlarge': (8, 0.532),
-    'r4.4xlarge': (16, 1.064),
-}
 
 # The annealer prints summary lines `Total Iterations: <n>` and `Total Perturbations: <n>` in
 # java_app.<port>.log. Anchor on each exact phrase (so `Total Perturbations`, the energy block's
@@ -176,22 +95,6 @@ def parse_final_energy(lines: list[str]) -> float | None:
                     energy = float(match.group(1))
                     break
     return energy
-
-
-def duration_seconds(summary: dict[str, Any]) -> float | None:
-    """Wall seconds from a Batch JobSummary's epoch-millis timestamps, or ``None`` if not both present."""
-    started, stopped = summary.get('startedAt'), summary.get('stoppedAt')
-    if started is None or stopped is None:
-        return None
-    return max(0.0, (stopped - started) / 1000.0)
-
-
-def job_cost_usd(instance_type: str | None, job_vcpu: int, seconds: float | None) -> float | None:
-    """Fair-share cost = (instance $/hr / instance vCPU) x job vCPU x hours; ``None`` if unpriceable."""
-    if instance_type is None or seconds is None or instance_type not in INSTANCE_SPECS:
-        return None
-    instance_vcpu, usd_per_hour = INSTANCE_SPECS[instance_type]
-    return (usd_per_hour / instance_vcpu) * job_vcpu * (seconds / 3600.0)
 
 
 def build_toshi_api() -> ToshiApi:

--- a/scripts/ec2_sizing/coulomb_rupture_set.template.json
+++ b/scripts/ec2_sizing/coulomb_rupture_set.template.json
@@ -1,0 +1,21 @@
+{
+    "title": "EC2 sizing benchmark - coulomb rupture set",
+    "description": "Coulomb rupture-set build used to benchmark EC2 vCPU/family cost vs wall-clock completion time. submit_coulomb_matrix.py injects submission_arg_overrides (ecs_vcpu, java_threads=vcpu, ecs_memory) per cell; the build runs to completion so wall time is the metric.",
+
+    "max_sections": 2000,
+    "max_jump_distance": 15,
+    "adaptive_min_distance": 6,
+    "thinning_factor": 0,
+    "min_sub_sects_per_parent": 2,
+    "min_sub_sections": 2,
+    "scaling_relationship": "SIMPLE_CRUSTAL",
+
+    "depth_scaling":
+        {
+            "sans": 0.8,
+            "tvz": 0.667
+        }
+    ,
+
+    "fault_model": "CFM_1_0A_DOM_SANSTVZ"
+}

--- a/scripts/ec2_sizing/submit_coulomb_matrix.py
+++ b/scripts/ec2_sizing/submit_coulomb_matrix.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+"""Submit the EC2 job-sizing benchmark matrix for the coulomb rupture-set builder (#323).
+
+Unlike the crustal inversion (time-bounded, throughput = iterations), the coulomb builder runs *to
+completion*, so the metric is **wall-clock time** and the knobs that matter are **cores** and **instance
+family**. Each matrix cell is its own ``runzi rupset coulomb`` submit with distinct
+``submission_arg_overrides``:
+
+  - ``ecs_vcpu`` = the cell's core count,
+  - ``java_threads`` = ``ecs_vcpu`` (the builder calls ``setNumThreads(java_threads)``, so each cell
+    actually uses all the cores it pays for — this is what makes the wall-time-vs-cores curve meaningful),
+  - ``ecs_memory`` = sized to ~fill the family's per-vCPU RAM, so a compute-optimized (2 GB/vCPU) cell
+    that OOMs *reveals* that the build needs more memory than c-family provides.
+
+``swept_args`` can't sweep submission-side sizing fields, hence one submit per cell.
+
+Instance families are pinned by routing each cell to a per-family Batch queue (stood up by
+``terraform/ec2-sizing-benchmark/``). Pass ``--queue-prefix`` (the terraform ``name_prefix``, default
+``ec2sizing``); each cell then targets ``{prefix}-{family}-Q``. Without ``--queue-prefix`` all cells go to
+the job definition's derived ``runzi-ec2`` queue (an unpinned smoke test, where Batch "optimal" picks
+the instance).
+
+Usage::
+
+    # Dry run: render + print the per-cell overrides, no AWS calls.
+    python scripts/ec2_sizing/submit_coulomb_matrix.py --dry-run
+
+    # Pilot: ONE short cell to confirm the image + wall-clock path before spending the full matrix.
+    python scripts/ec2_sizing/submit_coulomb_matrix.py --limit 1 --manifest scratch/pilot.json
+
+    # Full matrix, families pinned via the terraform benchmark queues.
+    python scripts/ec2_sizing/submit_coulomb_matrix.py --queue-prefix ec2sizing \
+        --manifest scripts/ec2_sizing/coulomb_manifest.json
+
+Feed the resulting manifest to ``collect_coulomb_results.py`` once the jobs finish.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime as dt
+import json
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+# vCPU counts to test, threads pinned to vCPU per cell. Spans 16x to expose the parallel-scaling knee:
+# where extra cores stop cutting wall time enough to justify their cost.
+VCPUS = (4, 8, 16, 32, 64)
+
+# family -> MB per vCPU. Sized to ~fill each family's per-vCPU RAM (leaving agent headroom under the
+# instance ceiling: c/m/r ~= 2/4/8 GB per vCPU), so a c-family OOM is the signal that the build needs
+# more than 2 GB/vCPU. The family also selects the pinned Batch queue ({prefix}-{family}-Q).
+FAMILY_MB_PER_VCPU = {'c6a': 1800, 'm6a': 3800, 'r6a': 7600, 'c6i': 1800, 'm6i': 3800, 'r6i': 7600}
+
+DEFAULT_FAMILIES = ('c6a', 'm6a')  # compute-optimized vs general purpose, both AMD (cheapest x86)
+DEFAULT_REPLICATES = 2
+DEFAULT_QUEUE_PREFIX = 'ec2sizing'  # matches terraform/ec2-sizing-benchmark var.name_prefix
+TEMPLATE = Path(__file__).with_name('coulomb_rupture_set.template.json')
+
+
+@dataclass(frozen=True)
+class Cell:
+    """One matrix cell: an (instance family, vCPU) point plus its replicate index."""
+
+    family: str
+    vcpu: int
+    memory_mb: int
+    replicate: int
+
+    @property
+    def threads(self) -> int:
+        """Anneal/build thread count — pinned to vCPU so the cell uses every core it pays for."""
+        return self.vcpu
+
+    @property
+    def cell_id(self) -> str:
+        return f'{self.family}-v{self.vcpu}-r{self.replicate}'
+
+
+def build_cells(replicates: int, families: list[str] | None = None, vcpus: list[int] | None = None) -> list[Cell]:
+    """Return the families x vcpus x replicates grid, in a stable order (all families/vCPUs unless given)."""
+    families = families if families is not None else list(DEFAULT_FAMILIES)
+    vcpus = vcpus if vcpus is not None else list(VCPUS)
+    cells: list[Cell] = []
+    for family in families:
+        mb_per_vcpu = FAMILY_MB_PER_VCPU[family]
+        for vcpu in vcpus:
+            for replicate in range(replicates):
+                cells.append(Cell(family=family, vcpu=vcpu, memory_mb=vcpu * mb_per_vcpu, replicate=replicate))
+    return cells
+
+
+def queue_for(cell: Cell, queue_prefix: str | None) -> str | None:
+    """The pinned Batch queue for a cell's family, or ``None`` (use the JD-derived runzi-ec2 queue)."""
+    return None if queue_prefix is None else f'{queue_prefix}-{cell.family}-Q'
+
+
+def render_config(
+    template: dict[str, Any],
+    cell: Cell,
+    max_job_time_min: int,
+    job_definition: str,
+    queue_prefix: str | None = None,
+) -> dict[str, Any]:
+    """Return a per-cell coulomb config: the template plus this cell's EC2 sizing overrides.
+
+    ``ecs_job_definition`` selects the target and the queue/compute-environment derive from it via
+    ``JOB_DEFINITION_TARGETS`` (ADR-0008), unless a ``queue_prefix`` routes the cell to a pinned
+    per-family benchmark queue (the JD is unchanged, so the compute-environment type stays EC2). JVM heap
+    follows ``ecs_memory`` automatically in ``aws.py``; ``java_threads`` is shipped to the worker and used
+    as ``setNumThreads``.
+    """
+    config = copy.deepcopy(template)
+    overrides: dict[str, Any] = {
+        'ecs_vcpu': cell.vcpu,
+        'java_threads': cell.threads,
+        'ecs_memory': cell.memory_mb,
+        'ecs_job_definition': job_definition,
+        'ecs_max_job_time_min': max_job_time_min,
+    }
+    queue = queue_for(cell, queue_prefix)
+    if queue is not None:
+        overrides['ecs_job_queue'] = queue
+    config['submission_arg_overrides'] = overrides
+    return config
+
+
+def submit_cell(config: dict[str, Any]) -> str:
+    """Submit one rendered config to AWS Batch and return its toshi general_task_id.
+
+    Calls the runner directly (as ``rupture_sets_cli.coulomb`` does) rather than shelling out, so the
+    general_task_id comes back as a clean return value. Sets ``local_config`` to AWS/API mode first,
+    exactly as the CLI's main callback does. ``USE_API`` is required: the general_task_id it mints is the
+    only link back to the cell's Batch job.
+    """
+    import runzi.automation.local_config as local_config
+    from runzi.arguments import ArgSweeper
+    from runzi.automation.local_config import ClusterModeEnum
+    from runzi.tasks.coulomb_rupture_sets import CoulombRuptureSetArgs, CoulombRuptureSetJobRunner
+
+    local_config.CLUSTER_MODE = ClusterModeEnum.AWS
+    local_config.USE_API = True
+
+    with tempfile.NamedTemporaryFile('w', suffix='.json', delete=False) as handle:
+        json.dump(config, handle)
+        config_path = Path(handle.name)
+    try:
+        job_input = ArgSweeper.from_config_file(config_path, CoulombRuptureSetArgs)
+        gt_id = CoulombRuptureSetJobRunner(job_input).run_jobs()
+    finally:
+        config_path.unlink(missing_ok=True)
+    if gt_id is None:  # USE_API is forced True above, so a general_task_id is always created.
+        raise RuntimeError('run_jobs() returned no general_task_id; is the toshi API configured?')
+    return gt_id
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--template', type=Path, default=TEMPLATE, help='Coulomb rupture-set template config JSON.')
+    parser.add_argument(
+        '--max-job-time-min',
+        type=int,
+        default=90,
+        help='Batch job time limit (minutes); must exceed the slowest (low-vCPU) build plus JVM/IO overhead.',
+    )
+    parser.add_argument('--replicates', type=int, default=DEFAULT_REPLICATES, help='Repeats per cell.')
+    parser.add_argument(
+        '--families',
+        nargs='+',
+        choices=list(FAMILY_MB_PER_VCPU),
+        default=None,
+        help='Which instance families to include (default c6a m6a). Each maps to a pinned queue and a memory ratio.',
+    )
+    parser.add_argument(
+        '--vcpus',
+        nargs='+',
+        type=int,
+        choices=list(VCPUS),
+        default=None,
+        help='Which vCPU counts to include (default all). threads are pinned to vCPU.',
+    )
+    parser.add_argument(
+        '--queue-prefix',
+        default=None,
+        help='Route each cell to the pinned per-family queue {prefix}-{family}-Q (the terraform name_prefix, '
+        f'e.g. {DEFAULT_QUEUE_PREFIX!r}). Omit to use the JD-derived runzi-ec2 queue (unpinned smoke test).',
+    )
+    parser.add_argument(
+        '--limit',
+        type=int,
+        default=None,
+        help='Submit only the first N cells of the grid (e.g. --limit 1 for a single-cell pilot).',
+    )
+    parser.add_argument(
+        '--manifest',
+        type=Path,
+        default=Path(__file__).with_name('coulomb_manifest.json'),
+        help='Where to write the {cell -> general_task_id} manifest.',
+    )
+    parser.add_argument(
+        '--prod',
+        action='store_true',
+        help='Target the :prod EC2 job definition instead of the default :experimental one.',
+    )
+    parser.add_argument('--dry-run', action='store_true', help='Render and print configs without submitting.')
+    args = parser.parse_args(argv)
+
+    from runzi.arguments import EC2_EXPERIMENTAL_JOB_DEFINITION, EC2_JOB_DEFINITION
+
+    # Default to the :experimental JD: a benchmark should exercise the latest-built image, and :prod may
+    # lag main (an out-of-date worker manifests as a py4j `127.0.0.1:None` gateway error).
+    job_definition = EC2_JOB_DEFINITION if args.prod else EC2_EXPERIMENTAL_JOB_DEFINITION
+
+    template = json.loads(args.template.read_text())
+    cells = build_cells(args.replicates, args.families, args.vcpus)
+    full_grid = len(cells)
+    if args.limit is not None:
+        cells = cells[: args.limit]
+
+    families = args.families if args.families is not None else list(DEFAULT_FAMILIES)
+    vcpus = args.vcpus if args.vcpus is not None else list(VCPUS)
+    target = f'{args.queue_prefix}-*-Q' if args.queue_prefix is not None else job_definition
+    print(
+        f'submitting {len(cells)} of {full_grid} cells to {target} '
+        f'({len(families)} families {families} x {len(vcpus)} vCPU {vcpus} x {args.replicates} replicates)'
+    )
+
+    manifest_rows: list[dict[str, Any]] = []
+    for cell in cells:
+        config = render_config(template, cell, args.max_job_time_min, job_definition, queue_prefix=args.queue_prefix)
+        if args.dry_run:
+            print(f'--- {cell.cell_id} (vcpu={cell.vcpu} threads={cell.threads} memory_mb={cell.memory_mb}) ---')
+            print(json.dumps(config['submission_arg_overrides']))
+            continue
+        gt_id = submit_cell(config)
+        print(f'{cell.cell_id}: general_task_id={gt_id}')
+        manifest_rows.append(
+            {
+                **asdict(cell),
+                'threads': cell.threads,
+                'cell_id': cell.cell_id,
+                'job_queue': queue_for(cell, args.queue_prefix),
+                'general_task_id': gt_id,
+            }
+        )
+
+    if args.dry_run:
+        return 0
+
+    manifest = {
+        'submitted_at': dt.datetime.now(dt.UTC).isoformat(),
+        'queue_prefix': args.queue_prefix,
+        'rows': manifest_rows,
+    }
+    args.manifest.write_text(json.dumps(manifest, indent=2))
+    print(f'wrote manifest: {args.manifest} ({len(manifest_rows)} submits)')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_ec2_coulomb_sizing.py
+++ b/tests/test_ec2_coulomb_sizing.py
@@ -1,0 +1,246 @@
+"""Tests for the coulomb rupture-set EC2 sizing benchmark scripts (#323).
+
+The scripts live under ``scripts/ec2_sizing/`` (not on the package path), so they're loaded by file
+path. Only the side-effect-free grid/render/analysis logic is covered — submit/collect I/O needs live AWS.
+The metric here is wall-clock time (from the Batch job summary), so there is no Toshi log to parse.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / 'scripts' / 'ec2_sizing'
+
+
+def _load(name: str) -> ModuleType:
+    module_name = f'ec2_sizing_{name}'
+    spec = importlib.util.spec_from_file_location(module_name, _SCRIPTS / f'{name}.py')
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module  # dataclasses resolves field types via sys.modules at exec time
+    spec.loader.exec_module(module)
+    return module
+
+
+submit = _load('submit_coulomb_matrix')
+collect = _load('collect_coulomb_results')
+
+
+class TestBuildCells:
+    def test_full_grid_size_is_families_x_vcpus_x_replicates(self):
+        cells = submit.build_cells(replicates=2)
+        assert len(cells) == len(submit.DEFAULT_FAMILIES) * len(submit.VCPUS) * 2
+
+    def test_threads_are_pinned_to_vcpu(self):
+        assert all(c.threads == c.vcpu for c in submit.build_cells(1))
+
+    def test_memory_is_vcpu_times_family_ratio(self):
+        cell = next(c for c in submit.build_cells(1) if c.family == 'c6a' and c.vcpu == 8)
+        assert cell.memory_mb == 8 * submit.FAMILY_MB_PER_VCPU['c6a']
+
+    def test_cell_id_is_unique_per_cell(self):
+        cells = submit.build_cells(2)
+        assert len({c.cell_id for c in cells}) == len(cells)
+
+    def test_families_filter_selects_only_given_families(self):
+        cells = submit.build_cells(1, families=['c6a'])
+        assert {c.family for c in cells} == {'c6a'}
+        assert len(cells) == len(submit.VCPUS)
+
+    def test_vcpus_filter_selects_only_given_vcpus(self):
+        cells = submit.build_cells(1, families=['m6a'], vcpus=[8])
+        assert [(c.family, c.vcpu) for c in cells] == [('m6a', 8)]
+
+
+class TestLimit:
+    def test_limit_one_dry_run_renders_single_cell(self, capsys):
+        rc = submit.main(['--limit', '1', '--dry-run'])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert 'submitting 1 of 20 cells' in out  # 2 families x 5 vCPU x 2 replicates
+        assert out.count('ecs_vcpu') == 1  # exactly one cell rendered
+
+    def test_no_limit_dry_run_renders_full_grid(self, capsys):
+        submit.main(['--replicates', '1', '--dry-run'])
+        assert 'submitting 10 of 10 cells' in capsys.readouterr().out  # 2 families x 5 vCPU x 1 replicate
+
+    def test_families_flag_shrinks_the_grid(self, capsys):
+        submit.main(['--families', 'c6a', '--replicates', '1', '--dry-run'])
+        assert 'submitting 5 of 5 cells' in capsys.readouterr().out  # 1 family x 5 vCPU x 1 replicate
+
+    def test_defaults_to_experimental_job_definition(self, capsys):
+        submit.main(['--limit', '1', '--dry-run'])
+        assert 'runzi-ec2-experimental-JD' in capsys.readouterr().out
+
+    def test_prod_flag_targets_prod_job_definition(self, capsys):
+        submit.main(['--limit', '1', '--prod', '--dry-run'])
+        assert '"ecs_job_definition": "runzi-ec2-JD"' in capsys.readouterr().out
+
+
+class TestRenderConfig:
+    def _template(self):
+        return {'max_sections': 2000, 'fault_model': 'CFM_1_0A_DOM_SANSTVZ'}
+
+    def test_injects_ec2_sizing_overrides_with_threads_pinned_to_vcpu(self):
+        cell = submit.Cell(family='c6a', vcpu=16, memory_mb=28800, replicate=0)
+        config = submit.render_config(self._template(), cell, 90, 'runzi-ec2-JD')
+        overrides = config['submission_arg_overrides']
+        assert overrides['ecs_vcpu'] == 16
+        assert overrides['java_threads'] == 16  # pinned to vCPU
+        assert overrides['ecs_memory'] == 28800
+        assert overrides['ecs_job_definition'] == 'runzi-ec2-JD'
+        assert overrides['ecs_max_job_time_min'] == 90
+
+    def test_leaves_template_untouched(self):
+        template = self._template()
+        cell = submit.Cell(family='c6a', vcpu=4, memory_mb=7200, replicate=0)
+        submit.render_config(template, cell, 90, 'runzi-ec2-experimental-JD')
+        assert 'submission_arg_overrides' not in template  # deep-copied, not mutated in place
+
+    def test_queue_prefix_routes_to_pinned_family_queue(self):
+        cell = submit.Cell(family='m6a', vcpu=8, memory_mb=30400, replicate=0)
+        config = submit.render_config(self._template(), cell, 90, 'runzi-ec2-experimental-JD', queue_prefix='ec2sizing')
+        assert config['submission_arg_overrides']['ecs_job_queue'] == 'ec2sizing-m6a-Q'
+
+    def test_no_job_queue_override_by_default(self):
+        cell = submit.Cell(family='c6a', vcpu=8, memory_mb=14400, replicate=0)
+        config = submit.render_config(self._template(), cell, 90, 'runzi-ec2-experimental-JD')
+        assert 'ecs_job_queue' not in config['submission_arg_overrides']  # queue derives from the JD
+
+
+class TestCollectRows:
+    def _manifest(self, job_queue: str | None = 'ec2sizing-c6a-Q'):
+        return {
+            'rows': [
+                {
+                    'general_task_id': 'gt1',
+                    'cell_id': 'c6a-v8-r0',
+                    'family': 'c6a',
+                    'vcpu': 8,
+                    'threads': 8,
+                    'memory_mb': 14400,
+                    'replicate': 0,
+                    'job_queue': job_queue,
+                }
+            ]
+        }
+
+    def _patch_batch(self, monkeypatch, instance: str | None = 'c6a.2xlarge', status='SUCCEEDED'):
+        monkeypatch.setattr(
+            collect,
+            'jobs_for_general_task',
+            lambda gt_id, queues=None: [
+                {'jobId': 'j1', 'status': status, 'startedAt': 1_000_000, 'stoppedAt': 1_600_000}
+            ],
+        )
+        monkeypatch.setattr(collect, 'instance_type_by_job_id', lambda job_ids: {'j1': instance} if instance else {})
+
+    def test_builds_duration_and_cost_from_batch_no_toshi(self, monkeypatch):
+        self._patch_batch(monkeypatch)
+        rows = collect.collect_rows(self._manifest())
+        assert len(rows) == 1
+        row = rows[0]
+        assert row['instance_type'] == 'c6a.2xlarge'
+        assert row['duration_sec'] == 600.0
+        assert row['threads'] == 8
+        assert row['cost_usd'] is not None  # priced from the fair-share formula
+
+    def test_pinned_run_is_priced_from_family_when_ecs_lookup_fails(self, monkeypatch):
+        # CE scaled to zero (or no ECS perms) -> read-back is empty/denied, but a pinned cell's instance
+        # is derived from family + vCPU, so cost still computes. This is the real-run failure mode.
+        from botocore.exceptions import ClientError
+
+        monkeypatch.setattr(
+            collect,
+            'jobs_for_general_task',
+            lambda gt_id, queues=None: [
+                {'jobId': 'j1', 'status': 'SUCCEEDED', 'startedAt': 1_000_000, 'stoppedAt': 1_600_000}
+            ],
+        )
+
+        def _deny(job_ids):
+            raise ClientError(
+                {'Error': {'Code': 'AccessDeniedException', 'Message': 'no'}}, 'DescribeContainerInstances'
+            )
+
+        monkeypatch.setattr(collect, 'instance_type_by_job_id', _deny)
+        row = collect.collect_rows(self._manifest())[0]  # c6a, 8 vCPU, pinned to ec2sizing-c6a-Q
+        assert row['instance_type'] == 'c6a.2xlarge'  # derived from family + vCPU, no read-back
+        assert row['cost_usd'] is not None
+        assert row['duration_sec'] == 600.0
+
+    def test_unpinned_cell_is_not_priced_from_family(self, monkeypatch):
+        # Without a per-family queue the instance is whatever "optimal" picked, so we must NOT assume the
+        # family. Unresolved read-back -> no instance, no cost.
+        self._patch_batch(monkeypatch, instance=None)
+        row = collect.collect_rows(self._manifest(job_queue=None))[0]
+        assert row['instance_type'] is None and row['cost_usd'] is None
+        assert row['duration_sec'] == 600.0  # duration still reported
+
+    def test_instance_type_override_prices_without_ecs_lookup(self, monkeypatch):
+        monkeypatch.setattr(
+            collect,
+            'jobs_for_general_task',
+            lambda gt_id, queues=None: [
+                {'jobId': 'j1', 'status': 'SUCCEEDED', 'startedAt': 1_000_000, 'stoppedAt': 1_600_000}
+            ],
+        )
+
+        def _boom(job_ids):
+            raise AssertionError('instance_type_by_job_id must not be called when overridden')
+
+        monkeypatch.setattr(collect, 'instance_type_by_job_id', _boom)
+        row = collect.collect_rows(self._manifest(), instance_type_override='c6a.4xlarge')[0]
+        assert row['instance_type'] == 'c6a.4xlarge'
+        assert row['cost_usd'] is not None  # priced despite no ECS lookup
+
+    def test_searches_the_given_queues(self, monkeypatch):
+        seen = {}
+
+        def _jobs(gt_id, queues=None):
+            seen['queues'] = queues
+            return []
+
+        monkeypatch.setattr(collect, 'jobs_for_general_task', _jobs)
+        monkeypatch.setattr(collect, 'instance_type_by_job_id', lambda job_ids: {})
+        collect.collect_rows(self._manifest(), queues=('ec2sizing-c6a-Q',))
+        assert seen['queues'] == ('ec2sizing-c6a-Q',)
+
+    def test_missing_job_survives_with_none_duration_and_cost(self, monkeypatch):
+        monkeypatch.setattr(collect, 'jobs_for_general_task', lambda gt_id, queues=None: [])
+        monkeypatch.setattr(collect, 'instance_type_by_job_id', lambda job_ids: {})
+        row = collect.collect_rows(self._manifest())[0]
+        assert row['duration_sec'] is None and row['cost_usd'] is None and row['status'] is None
+        assert row['cell_id'] == 'c6a-v8-r0'  # row still produced
+
+
+class TestExpectedInstanceType:
+    def test_maps_family_and_vcpu_to_exact_fit_size(self):
+        assert collect.expected_instance_type('c6a', 8) == 'c6a.2xlarge'
+        assert collect.expected_instance_type('m6a', 64) == 'm6a.16xlarge'
+        assert collect.expected_instance_type('c6a', 4) == 'c6a.xlarge'
+
+    def test_none_for_missing_family_or_unmapped_vcpu(self):
+        assert collect.expected_instance_type(None, 8) is None
+        assert collect.expected_instance_type('c6a', 7) is None  # not an exact-fit size
+
+    def test_none_when_derived_type_not_in_price_table(self):
+        assert collect.expected_instance_type('z9z', 8) is None  # unknown family -> not priced
+
+
+class TestCostPrimitives:
+    """The shared _cost.py primitives, re-exposed on the collector module."""
+
+    def test_duration_is_stopped_minus_started(self):
+        assert collect.duration_seconds({'startedAt': 1_000_000, 'stoppedAt': 1_600_000}) == 600.0
+
+    def test_duration_missing_timestamp_is_none(self):
+        assert collect.duration_seconds({'startedAt': 1_000_000}) is None
+
+    def test_fair_share_cost_is_per_vcpu_prorated(self):
+        # c6a.2xlarge: 8 vCPU, $0.306/hr. A 8-vCPU job for 1 hour = the full instance-hour.
+        assert collect.job_cost_usd('c6a.2xlarge', job_vcpu=8, seconds=3600.0) == round(0.306, 10)
+
+    def test_unknown_instance_type_is_none(self):
+        assert collect.job_cost_usd('t3.nano', 2, 3600.0) is None


### PR DESCRIPTION
## Summary

Adds a wall-clock EC2 job-sizing benchmark for the **coulomb rupture-set builder** — the sibling of the crustal-inversion benchmark (#323) — and applies its findings to the coulomb **and** subduction builder defaults.

Unlike the time-bounded inversion (throughput = iterations), the rupture-set builder runs *to completion*, so the metric is **wall-clock time** and the knobs that matter are **cores** and **instance family**.

## Benchmark tooling (`scripts/ec2_sizing/`)

- `submit_coulomb_matrix.py` / `collect_coulomb_results.py` — family × vCPU matrix, `java_threads` pinned to `ecs_vcpu` per cell, metric = wall-clock time + fair-share cost. No Toshi-log parsing (that's inversion-only) — wall time comes straight off the Batch job summary.
- `_cost.py` — EC2 price table + fair-share cost formula, extracted from `collect_results.py` so both collectors share one table (no drift).
- Pinned runs are priced **without an ECS instance read-back**: the type is derived from family + vCPU (the fair-share per-vCPU rate is size-independent within a family), so cost survives the compute environment scaling to zero.

## Findings

`docs/benchmarks/ec2-sizing-coulomb-rupture-set.md` — the build is **compute-bound and low-memory** (c6a ≈ m6a, no OOM at ~1.8 GB/vCPU), **scales sub-linearly** (16× cores → ~4× speedup), **knee at 32 vCPU**. c6a is cheapest at any sane size; cheapest \$/build = c6a · 4 vCPU.

## Applied — `default_submission_args` (coulomb + subduction)

| field | old | new | why |
|---|--:|--:|---|
| `ecs_vcpu` | 4 | 4 | cheapest \$/build (unchanged) |
| `java_threads` | 16 | 4 | track vCPU; 16-on-4 oversubscribed |
| `ecs_memory` (MiB) | 30720 | 8192 | ~2 GB/vCPU; build is low-memory; avoids r-family on `"optimal"` |
| `ecs_max_job_time_min` | 60 | 90 | the ~62 min 4-vCPU build **exceeded the old limit and was being killed** |

Subduction is assumed equivalent to coulomb (not independently benchmarked).

## Test plan

- `pytest tests/test_ec2_coulomb_sizing.py tests/test_ec2_sizing_scripts.py tests/test_get_ecs_job_config.py` — 121 pass (existing inversion tests still green after the `_cost.py` extraction).
- `mypy` clean on both builder modules; `ruff` clean on the new test file.
- Benchmark run against the live matrix produced the results in the findings doc.

Run artifacts (`coulomb_manifest.json`, `coulomb_results.csv`) are intentionally not committed, matching the existing inversion convention.

https://claude.ai/code/session_01Jcq9otxx7SoYxP5GN2KcES