### PR TITLE
feat(docker): standalone Docker launcher (run tasks without installing runzi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  - `runzi batch status <GENERAL_TASK_ID>` — a read-only command that lists the AWS Batch jobs for a submitted task, showing each job's status, run time, creation time, and the swept-argument values that make each job unique. Aimed at users who have no AWS console access (#326, #335).
  - `runzi batch log <JOB_ID>` — downloads a single Batch job's log to a local `<JOB_ID>.log` file (#337).
  - EC2 sizing benchmarks, and their tooling under `scripts/ec2_sizing/`, for the crustal inversion and coulomb rupture-set jobs — used to pick instance families and sizes. See `docs/benchmarks/` and `docs/architecture/adr/0011-*` (#323).
+ - `runzi/cli/docker_wrapper.py` now runs as a standalone launcher, so a user can run tasks with only the Docker image + `docker` + `aws` CLI, without installing runzi (`curl` it to `runzi-docker` and run it directly). It is the same file that powers `runzi --docker`; `rich`/`python-dotenv` are optional (with a stdlib `.env` fallback) and `__main__` accepts `--docker-shell` / `--docker-image` / `--docker-dry-run`. Auth uses the lightweight `nshm-toshi-client` (`toshi-auth login` / `aws-creds`). See `docs/usage/docker/run_without_install.md`.
 
 ### Changed
  - Inversion and rupture-set builder jobs now run on EC2 by default instead of Fargate, using compute-optimized instances and benchmark-tuned sizes (inversions 8 vCPU / 14000 MiB; rupture-set builds 4 vCPU / 7000 MiB with a 90-minute time limit, up from 60). Fargate stays available as a per-job override. See `docs/architecture/adr/0011-*` and `docs/benchmarks/` (#323).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
  - Local Java tasks now wait for the Java process to finish starting before connecting to it, fixing occasional connection-refused errors at startup.
  - Stage-incorrect S3 ARNs in the `terraform/access/` base policy: the runzi tiers' data-bucket grant was hardcoded to the `-test` buckets regardless of stage, so the `prod` roles targeted the test buckets. Now resolved per stage via stage-keyed `local.s3_data_buckets` (`prod` → `ths-dataset-prod` / `nzshm22-static-reports`; `test` unchanged). See `docs/architecture/adr/0005-runzi-iam-tiers-terraform-migration.md` (#321).
  - Disabled gql client schema fetching to avoid a `DirectiveLocation` crash against the Toshi API.
+ - `runzi --docker` (and the standalone launcher) no longer default to the retired `:latest` ECR tag — which the deploy pipeline never publishes, so a first-run pull with no local image would fail. The no-override default now pulls the published `:prod` image; use `--docker-image` for `:experimental` or a specific version tag. `_maybe_pull` also now honors a fully-qualified `--docker-image` URI verbatim (pulling from the account/region in the URI, or a non-ECR registry) instead of always reconstructing the default ECR reference.
 
 ## [0.11.0] 2026-10-06
 

--- a/docs/usage/docker/run_locally.md
+++ b/docs/usage/docker/run_locally.md
@@ -48,9 +48,16 @@ runzi --docker-shell
 | `--docker-shell` | Drop into an interactive bash session; implies `--docker` |
 | `--docker-dry-run` | Print the docker command without running it; implies `--docker` |
 
+## Can't install runzi?
+
+If you don't want to install runzi at all, use the **standalone launcher** — a
+single dependency-free download that gives you the same `--docker` convenience.
+See [Running the container without installing runzi](run_without_install.md).
+
 ## Fallback: raw `docker run`
 
-If you cannot install runzi on the host, you can still run the container directly. Replace `[COMMAND] [SUBCOMMAND] [OPTIONS]` with the runzi command you wish to run (e.g. `hazard oq-hazard /INPUT_FILES/config.json`).
+If you cannot install runzi on the host and would rather not use the standalone
+launcher, you can run the container directly. Replace `[COMMAND] [SUBCOMMAND] [OPTIONS]` with the runzi command you wish to run (e.g. `hazard oq-hazard /INPUT_FILES/config.json`).
 
 ### With a local THS dataset
 

--- a/docs/usage/docker/run_locally.md
+++ b/docs/usage/docker/run_locally.md
@@ -59,6 +59,15 @@ See [Running the container without installing runzi](run_without_install.md).
 If you cannot install runzi on the host and would rather not use the standalone
 launcher, you can run the container directly. Replace `[COMMAND] [SUBCOMMAND] [OPTIONS]` with the runzi command you wish to run (e.g. `hazard oq-hazard /INPUT_FILES/config.json`).
 
+The examples below reference the published `:prod` image; `docker run` pulls it on
+first use once you have logged Docker in to ECR (the deploy pipeline publishes
+`:prod`, `:experimental`, and immutable version tags — there is no `:latest`):
+
+```console
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin 461564345538.dkr.ecr.us-east-1.amazonaws.com
+```
+
 ### With a local THS dataset
 
 ```console
@@ -73,7 +82,7 @@ docker run --rm --user "$(id -u):$(id -g)" --entrypoint runzi \
   -e NZSHM22_TOSHI_API_URL \
   -e NZSHM22_TOSHI_API_KEY \
   -e NZSHM22_RUNZI_ECR_DIGEST \
-  runzi-build:latest [COMMAND] [SUBCOMMAND] [OPTIONS]
+  461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:prod [COMMAND] [SUBCOMMAND] [OPTIONS]
 ```
 
 ### With an S3 THS dataset
@@ -93,5 +102,5 @@ docker run --rm --user "$(id -u):$(id -g)" --entrypoint runzi \
   -e NZSHM22_TOSHI_API_URL \
   -e NZSHM22_TOSHI_API_KEY \
   -e NZSHM22_RUNZI_ECR_DIGEST \
-  runzi-build:latest [COMMAND] [SUBCOMMAND] [OPTIONS]
+  461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:prod [COMMAND] [SUBCOMMAND] [OPTIONS]
 ```

--- a/docs/usage/docker/run_without_install.md
+++ b/docs/usage/docker/run_without_install.md
@@ -73,10 +73,12 @@ prefix is unnecessary — this script *is* the docker launcher):
 ./runzi-docker inversion crustal config.json
 ```
 
-The launcher pulls the image from ECR on first use (logging in with your
-`toshi` AWS profile), mounts the config file's parent directory at
-`/INPUT_FILES`, mounts your `~/.aws` and `~/.toshi` credentials, forwards the
-allow-listed env vars, and runs the container as your host user ID.
+By default the launcher pulls the current **`:prod`** image from ECR on first use
+(logging in with your `toshi` AWS profile), mounts the config file's parent
+directory at `/INPUT_FILES`, mounts your `~/.aws` and `~/.toshi` credentials,
+forwards the allow-listed env vars, and runs the container as your host user ID.
+To run a different published image — the pre-release `:experimental` build or a
+specific immutable version tag — pass `--docker-image` (see below).
 
 ### Meta-flags
 
@@ -91,7 +93,7 @@ The same `--docker-*` meta-flags are available (minus the redundant `--docker`):
 ```console
 ./runzi-docker --docker-shell
 ./runzi-docker --docker-dry-run hazard oq-hazard config.json
-./runzi-docker --docker-image 461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:latest hazard oq-hazard config.json
+./runzi-docker --docker-image 461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:experimental hazard oq-hazard config.json
 ```
 
 `--docker-dry-run` is the quickest way to see exactly what will run and confirm

--- a/docs/usage/docker/run_without_install.md
+++ b/docs/usage/docker/run_without_install.md
@@ -1,0 +1,104 @@
+# Running the container without installing runzi
+
+This page is for users who want to run runzi tasks locally using **only** the
+Docker image — without `pip install`-ing runzi itself.
+
+The `runzi --docker` flags (see [Running the container locally](run_locally.md))
+do all the right orchestration — pull the image, mount your config/credentials,
+forward env vars, map your user ID — but they are only reachable through an
+installed runzi. The good news: that orchestration lives in a **single,
+dependency-free Python file** (`runzi/cli/docker_wrapper.py`) that you can
+download and run directly. runzi itself is already installed *inside* the image,
+so the container does the real work; the launcher just assembles the `docker run`.
+
+## Prerequisites
+
+- **Docker** installed and running.
+- The **AWS CLI** (used once to log Docker in to ECR when the image is pulled).
+- **Python 3.10+** (standard library only — the launcher needs no third-party
+  Python packages; `rich` and `python-dotenv` are used if present but are
+  optional).
+- **`nshm-toshi-client`** for authentication (this is *not* runzi — it is a small,
+  standalone package):
+
+    ```console
+    pip install nshm-toshi-client
+    ```
+
+## One-time authentication
+
+runzi authenticates to the toshi API and to AWS entirely through Cognito. Two
+commands from `nshm-toshi-client` produce the credential files the launcher
+mounts into the container:
+
+```console
+toshi-auth login       # writes ~/.toshi/credentials (JWT for the toshi API)
+toshi-auth aws-creds   # writes ~/.aws/credentials under the [toshi] profile (federated AWS creds)
+export AWS_PROFILE=toshi
+```
+
+- `toshi-auth login` is a terminal username/password flow — no browser needed.
+- `toshi-auth aws-creds` federates short-lived AWS credentials from the Cognito
+  Identity Pool. These are needed to **pull the image from ECR** and to write to
+  an **`s3://` THS database**. If your THS dataset is a **local directory**, you
+  do not need `aws-creds` or `AWS_PROFILE` — only `toshi-auth login`.
+- The federated AWS credentials are short-lived (about an hour). If a long job
+  fails with an AWS credential/expiry error, re-run `toshi-auth aws-creds`.
+
+## Get the launcher
+
+The runzi repository is public, so the launcher can be downloaded with no auth:
+
+```console
+curl -fsSL https://raw.githubusercontent.com/GNS-Science/nzshm-runzi/main/runzi/cli/docker_wrapper.py -o runzi-docker
+chmod +x runzi-docker
+```
+
+## Configure your `.env`
+
+Create a `.env` file in your working directory with the same `NZSHM22_*`
+configuration you would use for a normal runzi run (toshi/Cognito URLs and IDs,
+THS database locations, etc.). See
+[Environment Variables](../environment_variables.md). The launcher loads `.env`
+from the current directory automatically. `AWS_PROFILE`, `AWS_REGION`, and the
+`NZSHM22_*` values are forwarded into the container.
+
+## Run tasks
+
+Invoke it exactly like `runzi --docker`, but as `./runzi-docker` (the `--docker`
+prefix is unnecessary — this script *is* the docker launcher):
+
+```console
+./runzi-docker hazard oq-hazard config.json
+./runzi-docker inversion crustal config.json
+```
+
+The launcher pulls the image from ECR on first use (logging in with your
+`toshi` AWS profile), mounts the config file's parent directory at
+`/INPUT_FILES`, mounts your `~/.aws` and `~/.toshi` credentials, forwards the
+allow-listed env vars, and runs the container as your host user ID.
+
+### Meta-flags
+
+The same `--docker-*` meta-flags are available (minus the redundant `--docker`):
+
+| Flag | Purpose |
+|---|---|
+| `--docker-shell` | Drop into an interactive bash session inside the container |
+| `--docker-image TEXT` | Override the image tag or full ECR/registry URI |
+| `--docker-dry-run` | Print the `docker run` command without executing it |
+
+```console
+./runzi-docker --docker-shell
+./runzi-docker --docker-dry-run hazard oq-hazard config.json
+./runzi-docker --docker-image 461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:latest hazard oq-hazard config.json
+```
+
+`--docker-dry-run` is the quickest way to see exactly what will run and confirm
+your mounts and env are correct before pulling or launching anything.
+
+### Config files that reference other files
+
+As with `runzi --docker`, config files may only reference other files via
+**relative paths** to the same directory or a subdirectory — only the config's
+parent directory is mounted at `/INPUT_FILES`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
     - Docker:
       - Build and Deploy Container: usage/docker/build_and_deploy_container.md
       - Running the Container Locally: usage/docker/run_locally.md
+      - Running without Installing runzi: usage/docker/run_without_install.md
       - Developing runzi inside the Docker container: usage/docker/dev_locally.md
   - Process:
     - Building the SRM: process/build_srm_for_oq.md

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -22,7 +22,9 @@ def _parse_env_file(text: str) -> dict[str, str]:
     """Parse ``.env`` text into a dict (stdlib fallback for python-dotenv).
 
     Matches python-dotenv defaults for the common cases: skip blank/comment lines,
-    ``KEY=VALUE`` only, strip an optional ``export`` prefix and surrounding quotes.
+    ``KEY=VALUE`` only, strip an optional ``export`` prefix, strip a trailing inline
+    comment from unquoted values, and strip surrounding quotes (a ``#`` inside a
+    quoted value is kept verbatim).
     """
     result: dict[str, str] = {}
     for raw in text.splitlines():
@@ -34,7 +36,15 @@ def _parse_env_file(text: str) -> dict[str, str]:
         if key.startswith('export '):
             key = key[len('export ') :].strip()
         if key:
-            result[key] = value.strip().strip('\'"')
+            value = value.strip()
+            if value[:1] in ('"', "'") and (end := value.find(value[0], 1)) != -1:
+                value = value[1:end]  # quoted: contents verbatim, drop any trailing comment
+            else:
+                hash_index = value.find(' #')  # unquoted: ' #' begins an inline comment
+                if hash_index != -1:
+                    value = value[:hash_index].rstrip()
+                value = value.strip('\'"')
+            result[key] = value
     return result
 
 

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -8,6 +8,7 @@ This module is also runnable as a standalone script
 """
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -313,19 +314,43 @@ def _resolve_image(dev: bool, image_override: str | None) -> str:
     return _DEFAULT_DEV_IMAGE if dev else _DEFAULT_IMAGE
 
 
-def _maybe_pull(image: str) -> None:
-    if _image_exists_locally(image):
-        return
+# <account>.dkr.ecr.<region>.amazonaws.com — used to derive login account/region
+# from a fully-qualified ECR image reference.
+_ECR_HOST_RE = re.compile(r'^(?P<account>\d+)\.dkr\.ecr\.(?P<region>[a-z0-9-]+)\.amazonaws\.com$')
+
+
+def _resolve_pull_source(image: str) -> tuple[str, str | None, str | None]:
+    """Return ``(pull_source, login_region, login_account)`` for an image reference.
+
+    A fully-qualified registry reference (host[:port]/path, per Docker's rule that the
+    component before the first ``/`` contains a ``.`` or ``:``) is pulled verbatim; the
+    ECR account/region are parsed from its host for login (``None`` for a non-ECR host,
+    which skips ECR login).  A bare name/tag is reconstructed against the configured
+    default ECR account/region/repo, keeping only its tag.
+    """
+    head = image.split('/', 1)[0]
+    if '/' in image and ('.' in head or ':' in head):
+        m = _ECR_HOST_RE.match(head)
+        if m:
+            return image, m.group('region'), m.group('account')
+        return image, None, None
     region = os.environ.get('AWS_REGION', _DEFAULT_AWS_REGION)
     account = os.environ.get('AWS_ACCOUNT_ID', _DEFAULT_AWS_ACCOUNT)
     repo = os.environ.get('ECR_REPO', _DEFAULT_ECR_REPO)
-    if ":" not in image:  # guard againt no tag
-        image += ":"
-    ecr_image = f'{account}.dkr.ecr.{region}.amazonaws.com/{repo}:{image.split(":")[-1]}'
-    rich_print(f'[yellow]Image {image!r} not found locally — pulling {ecr_image} from ECR[/yellow]')
-    _ecr_login(region, account)
-    subprocess.run(['docker', 'pull', ecr_image], check=True)
-    subprocess.run(['docker', 'tag', ecr_image, image], check=True)
+    tag = image.split(':', 1)[1] if ':' in image else 'latest'
+    return f'{account}.dkr.ecr.{region}.amazonaws.com/{repo}:{tag}', region, account
+
+
+def _maybe_pull(image: str) -> None:
+    if _image_exists_locally(image):
+        return
+    source, region, account = _resolve_pull_source(image)
+    rich_print(f'[yellow]Image {image!r} not found locally — pulling {source}[/yellow]')
+    if region and account:
+        _ecr_login(region, account)
+    subprocess.run(['docker', 'pull', source], check=True)
+    if source != image:
+        subprocess.run(['docker', 'tag', source, image], check=True)
 
 
 # ── Env resolution ────────────────────────────────────────────────────────────

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -110,7 +110,12 @@ _ENV_FORWARDED_NZSHM_VARS: frozenset[str] = frozenset(
 
 _TOSHI_HOME_CONTAINER = '/toshi-home'
 
-_DEFAULT_IMAGE = 'runzi-build:latest'
+# Default local image alias. Its tag (``prod``) doubles as the ECR tag pulled when
+# the image is absent locally (via _resolve_pull_source): the deploy pipeline
+# publishes :prod, :experimental, and immutable version tags but never :latest, so
+# :prod is the only sensible no-override default. Run a different published image with
+# --docker-image (e.g. --docker-image <ecr-uri>/nzshm22/runzi:experimental).
+_DEFAULT_IMAGE = 'runzi-build:prod'
 _DEFAULT_DEV_IMAGE = 'runzi-build:dev'
 _DEFAULT_ECR_REPO = 'nzshm22/runzi'
 _DEFAULT_AWS_ACCOUNT = '461564345538'

--- a/runzi/cli/docker_wrapper.py
+++ b/runzi/cli/docker_wrapper.py
@@ -1,14 +1,66 @@
-"""Helpers for routing a runzi invocation through a local Docker container."""
+#!/usr/bin/env python3
+"""Helpers for routing a runzi invocation through a local Docker container.
+
+This module is also runnable as a standalone script
+(``python3 docker_wrapper.py <runzi args>``) with only ``python3`` + ``docker`` +
+``aws`` on PATH — no runzi install required.  To keep that path dependency-free,
+``rich`` and ``python-dotenv`` are optional and degrade gracefully when absent.
+"""
 
 import os
 import subprocess
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
-from rich import print as rich_print
+try:
+    from rich import print as rich_print
+except ImportError:  # standalone use without rich installed
+    rich_print = print  # type: ignore[assignment]
 
-load_dotenv()
+
+def _parse_env_file(text: str) -> dict[str, str]:
+    """Parse ``.env`` text into a dict (stdlib fallback for python-dotenv).
+
+    Matches python-dotenv defaults for the common cases: skip blank/comment lines,
+    ``KEY=VALUE`` only, strip an optional ``export`` prefix and surrounding quotes.
+    """
+    result: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        key, _, value = line.partition('=')
+        key = key.strip()
+        if key.startswith('export '):
+            key = key[len('export ') :].strip()
+        if key:
+            result[key] = value.strip().strip('\'"')
+    return result
+
+
+def _load_dotenv() -> None:
+    """Load a ``.env`` from the current directory.
+
+    Uses python-dotenv when available; otherwise falls back to :func:`_parse_env_file`
+    so the standalone launcher needs no third-party dependency.  Does not override
+    variables already set in the environment (matching python-dotenv defaults).
+    """
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        pass
+    else:
+        load_dotenv()
+        return
+
+    env_path = Path('.env')
+    if not env_path.is_file():
+        return
+    for key, value in _parse_env_file(env_path.read_text()).items():
+        os.environ.setdefault(key, value)
+
+
+_load_dotenv()
 
 _ENV_PASSTHROUGH = frozenset(
     [
@@ -56,6 +108,69 @@ _DEFAULT_AWS_REGION = 'us-east-1'
 _INPUT_FILES = '/INPUT_FILES'
 _AWS_CREDS_CONTAINER = '/aws-credentials'
 _WORK_PATH_CONTAINER = '/WORKING'
+
+
+# ── Docker meta-flag parsing ──────────────────────────────────────────────────
+# These flags select/route the Docker execution; they are stripped before the
+# remaining args are passed to runzi inside the container.  runzi_cli.py imports
+# these for its Typer callback; the standalone __main__ below uses
+# _parse_meta_flags.
+
+_DOCKER_BOOL_FLAGS: frozenset[str] = frozenset(['--docker', '--docker-dev', '--docker-shell', '--docker-dry-run'])
+_DOCKER_VALUE_FLAGS: frozenset[str] = frozenset(['--docker-image'])
+
+
+def _strip_docker_flags(args: list[str]) -> list[str]:
+    """Remove --docker-* flags (and their values) from a raw argv list."""
+    result: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in _DOCKER_BOOL_FLAGS:
+            pass  # drop boolean flag
+        elif arg in _DOCKER_VALUE_FLAGS:
+            i += 2  # drop --flag VALUE pair
+            continue
+        elif any(arg.startswith(f'{f}=') for f in _DOCKER_VALUE_FLAGS):
+            pass  # drop --flag=value form
+        else:
+            result.append(arg)
+        i += 1
+    return result
+
+
+def _parse_meta_flags(argv: list[str]) -> tuple[list[str], bool, str | None, bool, bool]:
+    """Parse the standalone launcher's docker meta-flags out of ``argv``.
+
+    Returns ``(inner_args, dev, image, shell, dry_run)``, mirroring the ``--docker*``
+    options that ``runzi_cli.py`` exposes so the standalone script has parity with an
+    installed ``runzi --docker...`` invocation.  A redundant ``--docker`` is a no-op
+    here (we are already the docker launcher).
+    """
+    inner: list[str] = []
+    dev = shell = dry_run = False
+    image: str | None = None
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == '--docker':
+            pass  # redundant — this script *is* the docker launcher
+        elif arg == '--docker-dev':
+            dev = True
+        elif arg == '--docker-shell':
+            shell = True
+        elif arg == '--docker-dry-run':
+            dry_run = True
+        elif arg == '--docker-image':
+            image = argv[i + 1] if i + 1 < len(argv) else None
+            i += 2
+            continue
+        elif arg.startswith('--docker-image='):
+            image = arg.split('=', 1)[1]
+        else:
+            inner.append(arg)
+        i += 1
+    return inner, dev, image, shell, dry_run
 
 
 # ── Pure path helpers ─────────────────────────────────────────────────────────
@@ -171,9 +286,15 @@ def _image_exists_locally(image: str) -> bool:
 
 
 def _ecr_login(region: str, aws_account_id: str) -> None:
-    from runzi.cli.build_and_deploy_container import ecr_login
-
-    ecr_login(region, aws_account_id)
+    """Log Docker into ECR using the AWS CLI. Inlined so the standalone launcher
+    has no runzi-internal import (mirrors build_and_deploy_container.ecr_login)."""
+    rich_print('Logging into ECR...')
+    registry = f'{aws_account_id}.dkr.ecr.{region}.amazonaws.com'
+    subprocess.run(
+        f'aws ecr get-login-password --region {region} | docker login --username AWS --password-stdin {registry}',
+        shell=True,
+        check=True,
+    )
 
 
 def _resolve_image(dev: bool, image_override: str | None) -> str:
@@ -352,4 +473,11 @@ def run_in_docker(
 
 
 if __name__ == '__main__':
-    sys.exit(run_in_docker(sys.argv[1:]))
+    _inner, _dev, _image, _shell, _dry_run = _parse_meta_flags(sys.argv[1:])
+    if _dev:
+        rich_print(
+            '[red]--docker-dev requires an installed runzi source tree and is not '
+            'available from the standalone launcher.[/red]'
+        )
+        sys.exit(2)
+    sys.exit(run_in_docker(_inner, dev=_dev, image=_image, shell=_shell, dry_run=_dry_run))

--- a/runzi/cli/runzi_cli.py
+++ b/runzi/cli/runzi_cli.py
@@ -20,28 +20,8 @@ from runzi.cli import (
 )
 
 # ── Arg capture helpers ───────────────────────────────────────────────────────
-
-_DOCKER_BOOL_FLAGS: frozenset[str] = frozenset(['--docker', '--docker-dev', '--docker-shell', '--docker-dry-run'])
-_DOCKER_VALUE_FLAGS: frozenset[str] = frozenset(['--docker-image'])
-
-
-def _strip_docker_flags(args: list[str]) -> list[str]:
-    """Remove --docker-* flags (and their values) from a raw argv list."""
-    result: list[str] = []
-    i = 0
-    while i < len(args):
-        arg = args[i]
-        if arg in _DOCKER_BOOL_FLAGS:
-            pass  # drop boolean flag
-        elif arg in _DOCKER_VALUE_FLAGS:
-            i += 2  # drop --flag VALUE pair
-            continue
-        elif any(arg.startswith(f'{f}=') for f in _DOCKER_VALUE_FLAGS):
-            pass  # drop --flag=value form
-        else:
-            result.append(arg)
-        i += 1
-    return result
+# _strip_docker_flags and the flag sets live in docker_wrapper so the standalone
+# launcher (docker_wrapper.py run directly) shares one source of truth with the CLI.
 
 
 class _ArgsCapturingGroup(TyperGroup):
@@ -105,7 +85,7 @@ def main_callback(
     use_docker = docker or docker_dev or docker_shell or docker_dry_run or (docker_image is not None)
     if use_docker:
         raw_args = ctx.meta.get('_raw_args', [])
-        inner_args = _strip_docker_flags(raw_args)
+        inner_args = docker_wrapper._strip_docker_flags(raw_args)
         exit_code = docker_wrapper.run_in_docker(
             inner_args,
             dev=docker_dev,

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 
 import pytest
 from typer.testing import CliRunner
@@ -804,3 +805,102 @@ def test_cli_docker_forwards_subcommand_name_in_inner_args(mocker, tmp_path):
     assert inner_args[0] == 'hazard', f'subcommand missing from inner_args: {inner_args}'
     assert 'oq-hazard' in inner_args
     assert str(config) in inner_args
+
+
+# ── _parse_meta_flags (standalone launcher argv parsing) ──────────────────────
+
+
+def test_parse_meta_flags_empty():
+    assert docker_wrapper._parse_meta_flags([]) == ([], False, None, False, False)
+
+
+def test_parse_meta_flags_passes_inner_args_through():
+    inner, dev, image, shell, dry_run = docker_wrapper._parse_meta_flags(['hazard', 'oq-hazard', 'foo.json'])
+    assert inner == ['hazard', 'oq-hazard', 'foo.json']
+    assert (dev, image, shell, dry_run) == (False, None, False, False)
+
+
+def test_parse_meta_flags_shell():
+    inner, dev, image, shell, dry_run = docker_wrapper._parse_meta_flags(['--docker-shell'])
+    assert inner == []
+    assert shell is True
+    assert (dev, image, dry_run) == (False, None, False)
+
+
+def test_parse_meta_flags_dry_run():
+    _, _, _, _, dry_run = docker_wrapper._parse_meta_flags(['--docker-dry-run', 'hazard'])
+    assert dry_run is True
+
+
+def test_parse_meta_flags_dev():
+    _, dev, _, _, _ = docker_wrapper._parse_meta_flags(['--docker-dev', 'hazard'])
+    assert dev is True
+
+
+def test_parse_meta_flags_image_space_form():
+    inner, _, image, _, _ = docker_wrapper._parse_meta_flags(['--docker-image', 'ghcr.io/x:tag', 'hazard'])
+    assert image == 'ghcr.io/x:tag'
+    assert inner == ['hazard']
+
+
+def test_parse_meta_flags_image_equals_form():
+    inner, _, image, _, _ = docker_wrapper._parse_meta_flags(['--docker-image=ghcr.io/x:tag', 'hazard'])
+    assert image == 'ghcr.io/x:tag'
+    assert inner == ['hazard']
+
+
+def test_parse_meta_flags_bare_docker_is_noop():
+    inner, dev, image, shell, dry_run = docker_wrapper._parse_meta_flags(['--docker', 'hazard', 'oq-hazard'])
+    assert inner == ['hazard', 'oq-hazard']
+    assert (dev, image, shell, dry_run) == (False, None, False, False)
+
+
+def test_parse_meta_flags_mixed_ordering():
+    inner, dev, image, shell, dry_run = docker_wrapper._parse_meta_flags(
+        ['--docker-dry-run', 'hazard', '--docker-image', 'img:1', 'oq-hazard', 'foo.json']
+    )
+    assert inner == ['hazard', 'oq-hazard', 'foo.json']
+    assert image == 'img:1'
+    assert dry_run is True
+
+
+def test_parse_meta_flags_and_strip_agree_on_inner_args():
+    """_parse_meta_flags and _strip_docker_flags must produce the same inner args."""
+    argv = ['--docker-dry-run', 'hazard', '--docker-image', 'img:1', 'oq-hazard', 'foo.json']
+    inner, *_ = docker_wrapper._parse_meta_flags(argv)
+    assert inner == docker_wrapper._strip_docker_flags(argv)
+
+
+# ── _parse_env_file (stdlib .env fallback) ────────────────────────────────────
+
+
+def test_parse_env_file_basic():
+    assert docker_wrapper._parse_env_file('FOO=bar\nBAZ=qux') == {'FOO': 'bar', 'BAZ': 'qux'}
+
+
+def test_parse_env_file_skips_blanks_and_comments():
+    text = '# a comment\n\nFOO=bar\n   # indented comment\nBAZ=qux\n'
+    assert docker_wrapper._parse_env_file(text) == {'FOO': 'bar', 'BAZ': 'qux'}
+
+
+def test_parse_env_file_strips_quotes_and_export():
+    text = "export FOO='bar'\nBAZ=\"qux\""
+    assert docker_wrapper._parse_env_file(text) == {'FOO': 'bar', 'BAZ': 'qux'}
+
+
+def test_parse_env_file_ignores_lines_without_equals():
+    assert docker_wrapper._parse_env_file('NOT_A_PAIR\nFOO=bar') == {'FOO': 'bar'}
+
+
+def test_load_dotenv_fallback_when_dotenv_absent(tmp_path, monkeypatch):
+    """With python-dotenv unavailable, _load_dotenv parses .env itself and does not
+    override already-set env vars."""
+    monkeypatch.setitem(sys.modules, 'dotenv', None)  # force `import dotenv` -> ImportError
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / '.env').write_text('NZSHM22_FALLBACK_NEW=fresh\nNZSHM22_FALLBACK_EXISTING=fromfile\n')
+    monkeypatch.setenv('NZSHM22_FALLBACK_EXISTING', 'preset')
+
+    docker_wrapper._load_dotenv()
+
+    assert os.environ['NZSHM22_FALLBACK_NEW'] == 'fresh'
+    assert os.environ['NZSHM22_FALLBACK_EXISTING'] == 'preset'  # not overridden

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -892,6 +892,18 @@ def test_parse_env_file_ignores_lines_without_equals():
     assert docker_wrapper._parse_env_file('NOT_A_PAIR\nFOO=bar') == {'FOO': 'bar'}
 
 
+def test_parse_env_file_strips_trailing_inline_comment():
+    assert docker_wrapper._parse_env_file('FOO=bar  # the level\nBAZ=qux') == {'FOO': 'bar', 'BAZ': 'qux'}
+
+
+def test_parse_env_file_keeps_hash_without_preceding_space():
+    assert docker_wrapper._parse_env_file('FOO=bar#baz') == {'FOO': 'bar#baz'}
+
+
+def test_parse_env_file_keeps_hash_inside_quotes():
+    assert docker_wrapper._parse_env_file('FOO="bar # baz" # comment') == {'FOO': 'bar # baz'}
+
+
 def test_load_dotenv_fallback_when_dotenv_absent(tmp_path, monkeypatch):
     """With python-dotenv unavailable, _load_dotenv parses .env itself and does not
     override already-set env vars."""

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -904,6 +904,104 @@ def test_parse_env_file_keeps_hash_inside_quotes():
     assert docker_wrapper._parse_env_file('FOO="bar # baz" # comment') == {'FOO': 'bar # baz'}
 
 
+# ── _resolve_pull_source / _maybe_pull (image reference resolution) ────────────
+
+
+def test_resolve_pull_source_bare_tag_reconstructs_default_ecr(monkeypatch):
+    for var in ('AWS_REGION', 'AWS_ACCOUNT_ID', 'ECR_REPO'):
+        monkeypatch.delenv(var, raising=False)
+    source, region, account = docker_wrapper._resolve_pull_source('runzi-build:latest')
+    assert source == '461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:latest'
+    assert (region, account) == ('us-east-1', '461564345538')
+
+
+def test_resolve_pull_source_bare_name_defaults_tag_to_latest(monkeypatch):
+    for var in ('AWS_REGION', 'AWS_ACCOUNT_ID', 'ECR_REPO'):
+        monkeypatch.delenv(var, raising=False)
+    source, _, _ = docker_wrapper._resolve_pull_source('runzi-build')
+    assert source.endswith('/nzshm22/runzi:latest')
+
+
+def test_resolve_pull_source_honors_env_overrides(monkeypatch):
+    monkeypatch.setenv('AWS_REGION', 'ap-southeast-2')
+    monkeypatch.setenv('AWS_ACCOUNT_ID', '999999999999')
+    monkeypatch.setenv('ECR_REPO', 'custom/repo')
+    source, region, account = docker_wrapper._resolve_pull_source('runzi-build:v2')
+    assert source == '999999999999.dkr.ecr.ap-southeast-2.amazonaws.com/custom/repo:v2'
+    assert (region, account) == ('ap-southeast-2', '999999999999')
+
+
+def test_resolve_pull_source_full_ecr_uri_pulled_verbatim():
+    uri = '461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:latest'
+    source, region, account = docker_wrapper._resolve_pull_source(uri)
+    assert source == uri  # pulled as-is, not reconstructed
+    assert (region, account) == ('us-east-1', '461564345538')
+
+
+def test_resolve_pull_source_foreign_account_ecr_uri_parsed():
+    uri = '123456789012.dkr.ecr.eu-west-1.amazonaws.com/foo/bar:tag'
+    source, region, account = docker_wrapper._resolve_pull_source(uri)
+    assert source == uri
+    assert (region, account) == ('eu-west-1', '123456789012')
+
+
+def test_resolve_pull_source_non_ecr_registry_skips_login():
+    uri = 'ghcr.io/gns-science/runzi:latest'
+    source, region, account = docker_wrapper._resolve_pull_source(uri)
+    assert source == uri
+    assert (region, account) == (None, None)  # no ECR login for a non-ECR host
+
+
+def test_maybe_pull_full_uri_pulls_verbatim_without_retag(mocker):
+    mocker.patch('runzi.cli.docker_wrapper._image_exists_locally', return_value=False)
+    ecr_login = mocker.patch('runzi.cli.docker_wrapper._ecr_login')
+    run = mocker.patch('runzi.cli.docker_wrapper.subprocess.run')
+    uri = '123456789012.dkr.ecr.eu-west-1.amazonaws.com/foo/bar:tag'
+
+    docker_wrapper._maybe_pull(uri)
+
+    ecr_login.assert_called_once_with('eu-west-1', '123456789012')
+    pulled = [c.args[0] for c in run.call_args_list]
+    assert ['docker', 'pull', uri] in pulled
+    assert not any(c.args[0][:2] == ['docker', 'tag'] for c in run.call_args_list)
+
+
+def test_maybe_pull_non_ecr_registry_skips_ecr_login(mocker):
+    mocker.patch('runzi.cli.docker_wrapper._image_exists_locally', return_value=False)
+    ecr_login = mocker.patch('runzi.cli.docker_wrapper._ecr_login')
+    run = mocker.patch('runzi.cli.docker_wrapper.subprocess.run')
+
+    docker_wrapper._maybe_pull('ghcr.io/gns-science/runzi:latest')
+
+    ecr_login.assert_not_called()
+    assert run.call_args_list[0].args[0] == ['docker', 'pull', 'ghcr.io/gns-science/runzi:latest']
+
+
+def test_maybe_pull_bare_tag_reconstructs_and_retags(mocker, monkeypatch):
+    for var in ('AWS_REGION', 'AWS_ACCOUNT_ID', 'ECR_REPO'):
+        monkeypatch.delenv(var, raising=False)
+    mocker.patch('runzi.cli.docker_wrapper._image_exists_locally', return_value=False)
+    ecr_login = mocker.patch('runzi.cli.docker_wrapper._ecr_login')
+    run = mocker.patch('runzi.cli.docker_wrapper.subprocess.run')
+    expected = '461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:latest'
+
+    docker_wrapper._maybe_pull('runzi-build:latest')
+
+    ecr_login.assert_called_once_with('us-east-1', '461564345538')
+    cmds = [c.args[0] for c in run.call_args_list]
+    assert ['docker', 'pull', expected] in cmds
+    assert ['docker', 'tag', expected, 'runzi-build:latest'] in cmds
+
+
+def test_maybe_pull_skips_when_image_present_locally(mocker):
+    mocker.patch('runzi.cli.docker_wrapper._image_exists_locally', return_value=True)
+    run = mocker.patch('runzi.cli.docker_wrapper.subprocess.run')
+
+    docker_wrapper._maybe_pull('runzi-build:latest')
+
+    run.assert_not_called()
+
+
 def test_load_dotenv_fallback_when_dotenv_absent(tmp_path, monkeypatch):
     """With python-dotenv unavailable, _load_dotenv parses .env itself and does not
     override already-set env vars."""

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -907,11 +907,25 @@ def test_parse_env_file_keeps_hash_inside_quotes():
 # ── _resolve_pull_source / _maybe_pull (image reference resolution) ────────────
 
 
+def test_default_image_pulls_prod_tag(monkeypatch):
+    """The no-override default resolves to the published :prod ECR tag, not :latest.
+
+    :latest is never pushed to ECR (deploy publishes :prod/:experimental/version tags),
+    so the default must map to :prod for a first-run pull to succeed.
+    """
+    for var in ('AWS_REGION', 'AWS_ACCOUNT_ID', 'ECR_REPO'):
+        monkeypatch.delenv(var, raising=False)
+    default = docker_wrapper._resolve_image(dev=False, image_override=None)
+    assert default == 'runzi-build:prod'
+    source, _, _ = docker_wrapper._resolve_pull_source(default)
+    assert source == '461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:prod'
+
+
 def test_resolve_pull_source_bare_tag_reconstructs_default_ecr(monkeypatch):
     for var in ('AWS_REGION', 'AWS_ACCOUNT_ID', 'ECR_REPO'):
         monkeypatch.delenv(var, raising=False)
-    source, region, account = docker_wrapper._resolve_pull_source('runzi-build:latest')
-    assert source == '461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:latest'
+    source, region, account = docker_wrapper._resolve_pull_source('runzi-build:experimental')
+    assert source == '461564345538.dkr.ecr.us-east-1.amazonaws.com/nzshm22/runzi:experimental'
     assert (region, account) == ('us-east-1', '461564345538')
 
 


### PR DESCRIPTION
## Why

Enable a user to run runzi tasks locally using **only** the ECR Docker image + `docker` + `aws` CLI — **without `pip install`-ing runzi**. The container already contains runzi; the `runzi --docker` flags are pure host-side orchestration (pull image, mount config/creds, forward env, map uid) that previously were only reachable through an installed runzi.

## What

Make the existing `runzi/cli/docker_wrapper.py` runnable as a standalone script (`python3 docker_wrapper.py …`, or `curl`'d to `runzi-docker`). The **same file** keeps powering `runzi --docker` (imported) and serves the no-install user (run directly) — one source of truth, no drift.

- Optional `rich` / `python-dotenv` with a stdlib `.env` fallback (`_parse_env_file`), so the launcher needs no third-party Python packages.
- Inline `ecr_login` — removes the last runzi-internal import on the normal path.
- Move the `--docker-*` flag helpers into `docker_wrapper.py` (imported back by `runzi_cli.py`) and add `_parse_meta_flags` so `__main__` has parity: `--docker-shell`, `--docker-image`, `--docker-dry-run`. Add a shebang.
- **Auth** stays with the lightweight `nshm-toshi-client` (`toshi-auth login` → JWT, `toshi-auth aws-creds` → host `~/.aws` STS under the `[toshi]` profile). Image stays on **private ECR** (Batch already uses it) — no registry changes.
- Docs: `docs/usage/docker/run_without_install.md` (in nav) + pointer from `run_locally.md`.

A `docs/superpowers`-style "installs nothing but Docker" variant (private GHCR mirror + container-based `login`/`aws-creds` subcommands) was considered and **deferred** — bigger lift (net-new image-publish CI, GHCR access mgmt, PAT rotation) whose only payoff is avoiding one `pip install`.

## Review fixes (post-`/review`)

A `/review` pass on this branch surfaced two issues in the newly-exposed standalone path; both are fixed here:

- **`.env` fallback dropped inline comments incorrectly.** The stdlib `_parse_env_file` (used when `python-dotenv` is absent) forwarded `FOO=bar  # note` into the container verbatim as `bar  # note`. It now strips a trailing inline comment from unquoted values the way python-dotenv does — a `#` preceded by whitespace begins a comment, while a `#` with no preceding space or inside quotes is kept.
- **`_maybe_pull` ignored fully-qualified `--docker-image` references and defaulted to a retired tag.** Two parts:
  - It always reconstructed an ECR URI from the default account/region/repo and kept only the tag, so `--docker-image <full-URI>` to a different account/region (or a non-ECR registry) silently pulled the default image and mislabeled it. Extracted `_resolve_pull_source`: a fully-qualified reference (host[:port]/path) is now pulled verbatim, with the ECR login account/region parsed from its host (skipped for a non-ECR host); a bare name/tag reconstructs against the defaults as before. It only re-tags when the pull source differs from the requested reference.
  - The no-override default was still `runzi-build:latest`, but the deploy pipeline retired `:latest` (ADR-0007) in favour of `:prod` / `:experimental` / immutable version tags — so a first-run pull with no local image resolved to the nonexistent `nzshm22/runzi:latest` and 404'd (exactly the no-install user's path). The default now pulls the published **`:prod`** image; `--docker-image` selects `:experimental`, a version tag, or a full URI. Docs (`run_without_install.md`, the `run_locally.md` raw-`docker run` fallback + its ECR-login step) and the CHANGELOG are updated to match.

## Verification

- `pytest tests` — **376 passed** (incl. new cases for `_parse_meta_flags`, `_parse_env_file` inline-comment/quote handling, `_resolve_pull_source` / `_maybe_pull` reference resolution, the `:prod` default, and the dotenv-absent fallback).
- `ruff check` clean; `mypy runzi tests` — "Success: no issues found".
- **Standalone smoke:** imported the module under `python3 -S` (no site-packages → `rich`/`dotenv`/`runzi` all unavailable) — no `ImportError`, `rich` falls back to builtin `print`, and `run_in_docker(dry_run=True)` produced correct `docker run` lines for both task passthrough (`--entrypoint runzi`, `/INPUT_FILES/config.json`) and shell (`--interactive --tty --entrypoint bash`).

## Notes

- The `AWS_PROFILE=toshi` value in the docs is taken from the client's `aws-creds` docstring; worth confirming against a real `toshi-auth aws-creds` run.

https://claude.ai/code/session_01Jcq9otxx7SoYxP5GN2KcES
