### PR TITLE
Normalize general task and subtask argument serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- General task and subtask arguments are now serialized identically, so downstream consumers that match the two get an exact match. Both sides go through a single `serialize_arguments()` helper. Previously the general task serialized swept arguments straight from the config file, so a dict argument (e.g. `rupture_set`) carried the config file's key order while the subtask reported the args model's field order; unswept arguments were also dumped in python mode, rendering enums as reprs (`AggregationEnum.MEAN` instead of `mean`).
+
 ## [0.15.0] 2026-07-27
 
 ### Added

--- a/runzi/arguments.py
+++ b/runzi/arguments.py
@@ -69,6 +69,31 @@ JOB_DEFINITION_TARGETS: dict[str, BatchTarget] = {
 DEFAULT_BATCH_TARGET = BatchTarget(DEFAULT_JOB_QUEUE, ComputeEnvironment.FARGATE)
 
 
+def serialize_arguments(args: BaseModel, exclude: set[str] | None = None) -> dict[str, str]:
+    """Render a task's user arguments as the strings recorded against the toshi API.
+
+    This is the single source of truth for that rendering. Both the general task
+    (JobRunner._build_argument_list) and every subtask (create_task(arguments=...)) go through
+    here, so a subtask's recorded arguments are identical to the general task values they came
+    from, and downstream consumers that match the two can do so exactly. Serializing anywhere
+    else silently reintroduces mismatches: raw config values carry the key order of the config
+    file rather than the model's field order, and a python-mode model_dump renders enums and
+    paths as reprs ("AggregationEnum.MEAN") instead of their JSON form ("mean").
+
+    Values are stringified with str() rather than json.dumps() because nshm_toshi_client's
+    kvl_to_graphql interpolates them into a GraphQL query without escaping, where the double
+    quotes of JSON would break the query.
+
+    Args:
+        args: The task's user argument model.
+        exclude: Field names to leave out of the result.
+
+    Returns:
+        Field name to serialized value.
+    """
+    return {key: str(value) for key, value in args.model_dump(mode='json', exclude=exclude).items()}
+
+
 class SubmissionArgs(BaseModel):
     """Config the local submitter uses to shape and submit the AWS Batch job.
 

--- a/runzi/arguments.py
+++ b/runzi/arguments.py
@@ -77,8 +77,8 @@ def serialize_arguments(args: BaseModel, exclude: set[str] | None = None) -> dic
     here, so a subtask's recorded arguments are identical to the general task values they came
     from, and downstream consumers that match the two can do so exactly. Serializing anywhere
     else silently reintroduces mismatches: raw config values carry the key order of the config
-    file rather than the model's field order, and a python-mode model_dump renders enums and
-    paths as reprs ("AggregationEnum.MEAN") instead of their JSON form ("mean").
+    file rather than the model's field order, and a python-mode model_dump renders enums as
+    reprs ("AggregationEnum.MEAN" rather than "mean") and datetimes without their ISO 'T'.
 
     Values are stringified with str() rather than json.dumps() because nshm_toshi_client's
     kvl_to_graphql interpolates them into a GraphQL query without escaping, where the double

--- a/runzi/job_runner.py
+++ b/runzi/job_runner.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from multiprocessing.dummy import Pool
 from subprocess import check_call
 
-from runzi.arguments import ArgSweeper, SubmissionArgs
+from runzi.arguments import ArgSweeper, SubmissionArgs, serialize_arguments
 from runzi.automation import local_config
 from runzi.automation.local_config import WORKER_POOL_SIZE, ClusterModeEnum
 from runzi.automation.toshi_api import CreateGeneralTaskArgs, ModelType, SubtaskType
@@ -57,10 +57,21 @@ class JobRunner(ABC):
         pass
 
     def _build_argument_list(self) -> list[dict[str, str | list[str]]]:
-        """Build argument list for general task."""
-        unswepped_args = {k: [str(v)] for k, v in self.argument_sweeper.prototype_args.model_dump().items()}
-        swept_args = {k: [str(item) for item in v] for k, v in self.argument_sweeper.swept_args.items()}
-        all_args = unswepped_args | swept_args
+        """Build argument list for general task.
+
+        Built from the task objects themselves rather than from the raw config, and serialized
+        with serialize_arguments — the same call the subtasks use to record their own arguments.
+        That makes every general task value identical to the subtask value it produced. Reading
+        swept values straight off the ArgSweeper instead would leak the config file's key order
+        into dict arguments (e.g. rupture_set), which no longer matches the field order a subtask
+        reports after the value has been through the args model.
+        """
+        all_args: dict[str, list[str]] = {}
+        for task_args in self.argument_sweeper.get_tasks():
+            for key, value in serialize_arguments(task_args).items():
+                values = all_args.setdefault(key, [])
+                if value not in values:
+                    values.append(value)
         return [dict(k=key, v=value) for key, value in all_args.items()]
 
     def run_jobs(self) -> str | None:

--- a/runzi/job_runner.py
+++ b/runzi/job_runner.py
@@ -4,6 +4,7 @@ import datetime as dt
 import getpass
 import logging
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from multiprocessing.dummy import Pool
 from subprocess import check_call
 
@@ -66,13 +67,14 @@ class JobRunner(ABC):
         into dict arguments (e.g. rupture_set), which no longer matches the field order a subtask
         reports after the value has been through the args model.
         """
-        all_args: dict[str, list[str]] = {}
+        # Collect the distinct values each argument takes across the tasks, in first-seen order.
+        # Every task carries a value for every argument, so unswept arguments repeat the same one.
+        all_args: defaultdict[str, list[str]] = defaultdict(list)
         for task_args in self.argument_sweeper.get_tasks():
-            for key, value in serialize_arguments(task_args).items():
-                values = all_args.setdefault(key, [])
-                if value not in values:
-                    values.append(value)
-        return [dict(k=key, v=value) for key, value in all_args.items()]
+            for name, value in serialize_arguments(task_args).items():
+                if value not in all_args[name]:
+                    all_args[name].append(value)
+        return [dict(k=name, v=values) for name, values in all_args.items()]
 
     def run_jobs(self) -> str | None:
         """Launch jobs.

--- a/runzi/tasks/average_solutions/average_solutions_task.py
+++ b/runzi/tasks/average_solutions/average_solutions_task.py
@@ -10,7 +10,7 @@ from nshm_toshi_client.task_relation import TaskRelation
 from pydantic import BaseModel
 from solvis import InversionSolution
 
-from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs, serialize_arguments
 from runzi.automation.file_utils import download_files, get_output_file_id
 from runzi.automation.local_config import API_URL, S3_URL, SPOOF, WORK_PATH, get_auth_kwargs
 from runzi.automation.toshi_api import ModelType, SubtaskType, ToshiApi
@@ -119,7 +119,7 @@ class AverageSolutionsTask:
                     task_type=SubtaskType.AGGREGATE_SOLUTION.name,
                     model_type=self.model_type.name,
                 ),
-                arguments=self.user_args.model_dump(mode='json'),
+                arguments=serialize_arguments(self.user_args),
                 environment=environment,
             )
 

--- a/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
+++ b/runzi/tasks/coulomb_rupture_sets/coulomb_rupture_set_builder_task.py
@@ -14,7 +14,7 @@ from nshm_toshi_client.task_relation import TaskRelation
 from py4j.java_gateway import GatewayParameters, JavaGateway
 from pydantic import BaseModel, model_validator
 
-from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs, serialize_arguments
 from runzi.automation.file_utils import download_files, get_output_file_id
 from runzi.automation.local_config import API_URL, S3_URL, SPOOF, WORK_PATH, get_auth_kwargs
 from runzi.automation.toshi_api import ToshiApi
@@ -166,7 +166,7 @@ class CoulombRuptureSetBuilderTask:
                     task_type="RUPTURE_SET",
                     model_type="CRUSTAL",
                 ),
-                arguments=self.user_args.model_dump(mode='json'),
+                arguments=serialize_arguments(self.user_args),
                 environment=environment,
             )
 

--- a/runzi/tasks/inversion/inversion_solution_builder.py
+++ b/runzi/tasks/inversion/inversion_solution_builder.py
@@ -14,7 +14,7 @@ from nshm_toshi_client.task_relation import TaskRelation
 from py4j.java_gateway import GatewayParameters, JavaGateway, JavaObject
 from pydantic import BaseModel, model_validator
 
-from runzi.arguments import TaskRuntimeArgs
+from runzi.arguments import TaskRuntimeArgs, serialize_arguments
 from runzi.automation.file_utils import download_files, get_output_file_id
 from runzi.automation.local_config import API_URL, S3_URL, SPOOF, WORK_PATH, get_auth_kwargs
 from runzi.automation.toshi_api import ModelType, ToshiApi
@@ -329,7 +329,7 @@ class InversionSolutionBuilder(ABC):
                     model_type=self.model_type.name.upper(),
                     # general_task_id=general_task_id,
                 ),
-                arguments=self.user_args.model_dump(mode='json'),
+                arguments=serialize_arguments(self.user_args),
                 environment=environment,
             )
 

--- a/runzi/tasks/oq_hazard/oq_disagg_task.py
+++ b/runzi/tasks/oq_hazard/oq_disagg_task.py
@@ -21,7 +21,7 @@ from nzshm_model.psha_adapter.openquake import OpenquakeModelPshaAdapter
 from nzshm_model.psha_adapter.openquake.hazard_config import OpenquakeConfig
 from toshi_hazard_store.scripts.ths_disagg_import import store_disagg
 
-from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs, serialize_arguments
 from runzi.automation.local_config import (
     API_URL,
     ECR_DIGEST,
@@ -145,8 +145,8 @@ class OQDisaggTask:
                 gmcm_logic_tree=json.dumps(gmcm_logic_tree.to_dict()),
                 openquake_config=json.dumps(openquake_config.to_dict()),
             ),
-            arguments=self.user_args.model_dump(
-                mode='json', exclude={'hazard_model', 'srm_logic_tree', 'gmcm_logic_tree', 'hazard_config'}
+            arguments=serialize_arguments(
+                self.user_args, exclude={'hazard_model', 'srm_logic_tree', 'gmcm_logic_tree', 'hazard_config'}
             ),
             # arguments={"a": 1},
             environment=environment,

--- a/runzi/tasks/oq_hazard/oq_hazard_task.py
+++ b/runzi/tasks/oq_hazard/oq_hazard_task.py
@@ -20,7 +20,7 @@ from nzshm_model.psha_adapter.openquake import OpenquakeModelPshaAdapter
 from nzshm_model.psha_adapter.openquake.hazard_config import OpenquakeConfig
 from toshi_hazard_store.scripts.ths_rlz_import import store_hazard
 
-from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs, serialize_arguments
 from runzi.automation.local_config import (
     API_URL,
     ECR_DIGEST,
@@ -126,8 +126,8 @@ class OQHazardTask:
                 gmcm_logic_tree=json.dumps(gmcm_logic_tree.to_dict()),
                 openquake_config=json.dumps(openquake_config.to_dict()),
             ),
-            arguments=self.user_args.model_dump(
-                mode='json', exclude={'hazard_model', 'srm_logic_tree', 'gmcm_logic_tree', 'hazard_config'}
+            arguments=serialize_arguments(
+                self.user_args, exclude={'hazard_model', 'srm_logic_tree', 'gmcm_logic_tree', 'hazard_config'}
             ),
             # arguments={"a": 1},
             environment=environment,

--- a/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
+++ b/runzi/tasks/oq_opensha_convert/oq_opensha_convert_task.py
@@ -11,7 +11,7 @@ from nshm_toshi_client.task_relation import TaskRelation  # TODO deprecate
 from pydantic import BaseModel
 
 import runzi
-from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs, serialize_arguments
 from runzi.automation.file_utils import download_files, get_output_file_id
 from runzi.automation.local_config import API_URL, OQ_VENV, S3_URL, SPOOF, WORK_PATH, get_auth_kwargs
 from runzi.automation.toshi_api import ModelType, SubtaskType, ToshiApi
@@ -116,7 +116,7 @@ class OQConvertTask:
                     task_type=SubtaskType.SOLUTION_TO_NRML.name,
                     model_type=self.model_type.name.upper(),
                 ),
-                arguments=self.user_args.model_dump(mode='json'),
+                arguments=serialize_arguments(self.user_args),
                 environment={},
             )
 

--- a/runzi/tasks/scale_solution/scale_solution_task.py
+++ b/runzi/tasks/scale_solution/scale_solution_task.py
@@ -11,7 +11,7 @@ from nshm_toshi_client.task_relation import TaskRelation
 from pydantic import BaseModel
 from solvis import InversionSolution
 
-from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs, serialize_arguments
 from runzi.automation.file_utils import download_files, get_output_file_id
 from runzi.automation.local_config import API_URL, S3_URL, SPOOF, WORK_PATH, get_auth_kwargs
 from runzi.automation.toshi_api import ModelType, SubtaskType, ToshiApi
@@ -73,7 +73,7 @@ class ScaleSolutionTask:
                     task_type=SubtaskType.SCALE_SOLUTION.name,
                     model_type=self.model_type.name.upper(),
                 ),
-                arguments=self.user_args.model_dump(mode='json'),
+                arguments=serialize_arguments(self.user_args),
                 environment={},
             )
 

--- a/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
+++ b/runzi/tasks/subduction_rupture_sets/subduction_rupture_set_builder_task.py
@@ -12,7 +12,7 @@ from nshm_toshi_client.task_relation import TaskRelation
 from py4j.java_gateway import GatewayParameters, JavaGateway
 from pydantic import BaseModel
 
-from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import EC2_JOB_DEFINITION, SubmissionArgs, TaskLanguage, TaskRuntimeArgs, serialize_arguments
 from runzi.automation.local_config import API_URL, S3_URL, SPOOF, WORK_PATH, get_auth_kwargs
 from runzi.tasks.get_config import get_config
 
@@ -114,7 +114,7 @@ class SubductionRuptureSetBuilderTask:
                     task_type="RUPTURE_SET",
                     model_type="SUBDUCTION",
                 ),
-                arguments=self.user_args.model_dump(mode='json'),
+                arguments=serialize_arguments(self.user_args),
                 environment=environment,
             )
 

--- a/runzi/tasks/time_dependent_solution/time_dependent_solution_task.py
+++ b/runzi/tasks/time_dependent_solution/time_dependent_solution_task.py
@@ -9,7 +9,7 @@ from nshm_toshi_client.task_relation import TaskRelation
 from py4j.java_gateway import GatewayParameters, JavaGateway
 from pydantic import BaseModel
 
-from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs
+from runzi.arguments import SubmissionArgs, TaskLanguage, TaskRuntimeArgs, serialize_arguments
 from runzi.automation.file_utils import download_files, get_output_file_id
 from runzi.automation.local_config import API_URL, S3_URL, SPOOF, WORK_PATH, get_auth_kwargs
 from runzi.automation.toshi_api import ModelType, SubtaskType, ToshiApi
@@ -82,7 +82,7 @@ class TimeDependentSolutionTask:
                     task_type=SubtaskType.TIME_DEPENDENT_SOLUTION.name,
                     model_type=self.model_type.name,
                 ),
-                arguments=self.user_args.model_dump(mode='json'),
+                arguments=serialize_arguments(self.user_args),
                 environment={},
             )
 

--- a/tests/test_argument_serialization.py
+++ b/tests/test_argument_serialization.py
@@ -4,6 +4,7 @@ Downstream consumers match a subtask's recorded arguments against the argument l
 general task that spawned it, so both sides must render the same value as the same string.
 """
 
+import datetime as dt
 import json
 from enum import Enum
 from pathlib import Path
@@ -35,7 +36,7 @@ class RuptureSet(BaseModel):
 class SampleArgs(BaseModel):
     rupture_set: RuptureSet
     agg: Aggregate
-    locations_file: Path
+    created: dt.datetime
     reweight: bool
 
 
@@ -50,7 +51,7 @@ def _sample_args(**overrides) -> SampleArgs:
     data = {
         "rupture_set": {"rupture_set_id": "RmlsZTox", "tag": "a tag"},
         "agg": "mean",
-        "locations_file": "/tmp/sites.csv",
+        "created": "2026-08-05T12:00:00",
         "reweight": True,
     }
     return SampleArgs.model_validate(data | overrides)
@@ -63,15 +64,20 @@ def test_serialize_arguments_normalizes_nested_key_order():
 
 
 def test_serialize_arguments_uses_json_form():
-    """Enums and paths render as their JSON value, not their python repr."""
+    """Enums and datetimes render as their JSON value.
+
+    A python-mode dump would give 'Aggregate.MEAN' and a space-separated datetime instead.
+    Paths are not covered here: str() of a Path is already the plain path, so both dump modes
+    agree and there is nothing to pin down.
+    """
     serialized = serialize_arguments(_sample_args())
     assert serialized["agg"] == "mean"
-    assert serialized["locations_file"] == "/tmp/sites.csv"
+    assert serialized["created"] == "2026-08-05T12:00:00"
     assert serialized["rupture_set"] == "{'rupture_set_id': 'RmlsZTox', 'tag': 'a tag'}"
 
 
 def test_serialize_arguments_excludes_named_fields():
-    serialized = serialize_arguments(_sample_args(), exclude={"agg", "locations_file"})
+    serialized = serialize_arguments(_sample_args(), exclude={"agg", "created"})
     assert set(serialized) == {"rupture_set", "reweight"}
 
 

--- a/tests/test_argument_serialization.py
+++ b/tests/test_argument_serialization.py
@@ -1,0 +1,126 @@
+"""Tests that a general task and its subtasks serialize arguments identically.
+
+Downstream consumers match a subtask's recorded arguments against the argument list of the
+general task that spawned it, so both sides must render the same value as the same string.
+"""
+
+import json
+from enum import Enum
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from runzi.arguments import ArgSweeper, serialize_arguments
+from runzi.tasks.inversion import (
+    CrustalInversionArgs,
+    CrustalInversionJobRunner,
+    SubductionInversionArgs,
+    SubductionInversionJobRunner,
+)
+from runzi.tasks.oq_hazard import OQDisaggArgs, OQDisaggJobRunner, OQHazardArgs, OQHazardJobRunner
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class Aggregate(Enum):
+    MEAN = 'mean'
+
+
+class RuptureSet(BaseModel):
+    rupture_set_id: str
+    tag: str
+
+
+class SampleArgs(BaseModel):
+    rupture_set: RuptureSet
+    agg: Aggregate
+    locations_file: Path
+    reweight: bool
+
+
+@pytest.fixture(autouse=True)
+def no_api(monkeypatch):
+    """Keep _build_argument_list off the network (the OQ runners upload logic tree files)."""
+    monkeypatch.setattr("runzi.tasks.oq_hazard.oq_hazard_runner.USE_API", False)
+    monkeypatch.setattr("runzi.tasks.oq_hazard.oq_disagg_runner.USE_API", False)
+
+
+def _sample_args(**overrides) -> SampleArgs:
+    data = {
+        "rupture_set": {"rupture_set_id": "RmlsZTox", "tag": "a tag"},
+        "agg": "mean",
+        "locations_file": "/tmp/sites.csv",
+        "reweight": True,
+    }
+    return SampleArgs.model_validate(data | overrides)
+
+
+def test_serialize_arguments_normalizes_nested_key_order():
+    """A dict argument serializes in field order, whatever order the config file wrote it in."""
+    config_order = {"tag": "a tag", "rupture_set_id": "RmlsZTox"}  # reverse of RuptureSet's fields
+    assert serialize_arguments(_sample_args(rupture_set=config_order)) == serialize_arguments(_sample_args())
+
+
+def test_serialize_arguments_uses_json_form():
+    """Enums and paths render as their JSON value, not their python repr."""
+    serialized = serialize_arguments(_sample_args())
+    assert serialized["agg"] == "mean"
+    assert serialized["locations_file"] == "/tmp/sites.csv"
+    assert serialized["rupture_set"] == "{'rupture_set_id': 'RmlsZTox', 'tag': 'a tag'}"
+
+
+def test_serialize_arguments_excludes_named_fields():
+    serialized = serialize_arguments(_sample_args(), exclude={"agg", "locations_file"})
+    assert set(serialized) == {"rupture_set", "reweight"}
+
+
+def test_serialize_arguments_avoids_double_quotes():
+    """kvl_to_graphql interpolates these values into a GraphQL query without escaping."""
+    assert '"' not in serialize_arguments(_sample_args())["rupture_set"]
+
+
+def test_general_task_lists_swept_dict_arg_as_subtasks_report_it(tmp_path):
+    """The reported bug: a swept dict written in config order didn't match the subtask's dump."""
+    config = json.loads((FIXTURES / "crustal_inversion.json").read_text())
+    del config["rupture_set"]
+    config["swept_args"] = {
+        # keys deliberately in the opposite order to InversionArgs.RuptureSet's field order
+        "rupture_set": [
+            {"tag": "first rupture set", "rupture_set_id": "RmlsZTox"},
+            {"tag": "second rupture set", "rupture_set_id": "RmlsZToy"},
+        ]
+    }
+    config_file = tmp_path / "crustal_inversion.json"
+    config_file.write_text(json.dumps(config))
+
+    runner = CrustalInversionJobRunner(ArgSweeper.from_config_file(config_file, CrustalInversionArgs))
+    argument_list = {entry["k"]: entry["v"] for entry in runner._build_argument_list()}
+
+    assert argument_list["rupture_set"] == [
+        "{'rupture_set_id': 'RmlsZTox', 'tag': 'first rupture set'}",
+        "{'rupture_set_id': 'RmlsZToy', 'tag': 'second rupture set'}",
+    ]
+    for task_args in runner.argument_sweeper.get_tasks():
+        assert serialize_arguments(task_args)["rupture_set"] in argument_list["rupture_set"]
+
+
+@pytest.mark.parametrize(
+    "fixture,args_class,runner_class",
+    [
+        ("crustal_inversion.json", CrustalInversionArgs, CrustalInversionJobRunner),
+        ("subduction_inversion.json", SubductionInversionArgs, SubductionInversionJobRunner),
+        ("hazard_job.json", OQHazardArgs, OQHazardJobRunner),
+        ("disagg_job.json", OQDisaggArgs, OQDisaggJobRunner),
+    ],
+)
+def test_every_subtask_argument_appears_in_general_task_list(fixture, args_class, runner_class):
+    """Every value a subtask will record is present, verbatim, in the general task's list."""
+    runner = runner_class(ArgSweeper.from_config_file(FIXTURES / fixture, args_class))
+    argument_list = {entry["k"]: entry["v"] for entry in runner._build_argument_list()}
+
+    tasks = list(runner.argument_sweeper.get_tasks())
+    assert tasks, "fixture generated no tasks"
+    for task_args in tasks:
+        for name, value in serialize_arguments(task_args).items():
+            assert value in argument_list[name], f"subtask value for '{name}' missing from general task list"


### PR DESCRIPTION
## Problem

Downstream consumers match a subtask's recorded arguments against the argument list of the general task that spawned it, but the two sides serialized from different sources and in different modes, so the strings didn't match. Two independent divergences:

1. **Key order.** `JobRunner._build_argument_list()` read swept arguments straight off the `ArgSweeper` — i.e. the raw config values — so a dict argument carried the key order of the config file, while the subtask reported the args model's field order. Unswept args already went through `model_dump()`, which is the tell. Against `tests/fixtures/crustal_inversion.json`, where the config writes `tag` before `rupture_set_id` but `InversionArgs.RuptureSet` declares the reverse:

   ```
   GT  rupture_set: "{'tag': 'a rupture set', 'rupture_set_id': 'RmlsZToxMDAwNjk='}"
   AT  rupture_set:  {'rupture_set_id': 'RmlsZToxMDAwNjk=', 'tag': 'a rupture set'}
   ```

2. **Dump mode.** The general task used `model_dump()`, subtasks used `model_dump(mode='json')`. These coincide for `InversionArgs` but not generally — on `tests/fixtures/disagg_job.json`, `agg` was recorded as `AggregationEnum.MEAN` on the general task and `mean` on the subtask. Same latent problem for any `datetime` field.

## Fix

A single `serialize_arguments(args, exclude=None)` helper in `runzi/arguments.py` is now the source of truth for how a task's arguments are rendered for toshi, and both sides go through it.

`_build_argument_list()` now builds from the task objects yielded by `get_tasks()` rather than the raw config, collecting distinct values per key in first-seen order — so the general task list is by construction the set of values its subtasks will report. No extra cost; `validate_all_tasks()` already walks the full product.

The nine `create_task(arguments=...)` sites call the helper instead of dumping inline; the two OQ sites keep their exclusions via the new `exclude` parameter. `inversion_sub_solution_task.py` and `azimuthal_rupture_set_builder_task.py` are untouched — neither uses the `*Args` models, and the former raises `NotImplementedError` on entry.

Values are stringified with `str()` rather than `json.dumps()` because `nshm_toshi_client`'s `kvl_to_graphql` interpolates them into a GraphQL query without escaping, where JSON's double quotes would break the query.

## Tests

`tests/test_argument_serialization.py` — 9 tests: unit coverage of key-order normalization, the JSON form for enums/paths, `exclude`, and the no-double-quotes invariant; a regression test driving `CrustalInversionJobRunner` with `rupture_set` swept in reversed key order; and a parametrized check over all four real fixture/runner pairs that every subtask value appears verbatim in the general task list.

Verified these catch the bug by temporarily restoring the old `_build_argument_list` — 3 fail, including on `hazard_job.json` and `disagg_job.json`. Full suite (429 tests), ruff, and mypy are clean.

## Notes for review

- **The OQ general task payload grows ~25%** (47KB → 59KB on `hazard_job.json`) because `srm_logic_tree` now serializes as a JSON structure instead of a dataclass repr. Well inside API limits, and an improvement in one respect: the old repr contained raw newlines, which aren't legal inside a GraphQL string literal. Worth a sanity check that nothing downstream parses the old repr form.
- **Pre-existing escaping hazard, not addressed here:** `kvl_to_graphql` does no escaping, so a tag containing an apostrophe flips Python's `repr` to double quotes and corrupts the mutation. That fix belongs in `nshm_toshi_client`.

https://claude.ai/code/session_016D9RDd9CesRshJ9sz389XB
